### PR TITLE
countrycode: derive hash to use in hashmap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use phf::phf_map;
 use phf::Map;
 pub mod iso3166_2;
 pub mod iso3166_3;
+use std::hash::Hash;
 
 /// # Sample code
 /// ```
@@ -29,7 +30,7 @@ pub mod iso3166_3;
 /// ```
 
 /// Data for each Country Code defined by ISO 3166-1
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct CountryCode {
     ///English short name
     pub name: &'static str,


### PR DESCRIPTION
deriving Hash would makes it easy to use CountryCode inside HashMaps.

(I'm finding these use cases as I go through using the crate, I hope it's not too much of a bother for you!)