### PR TITLE
feat: add serde support for ISO3166 2/3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,19 +2,31 @@
 name = "rust_iso3166"
 version = "0.1.14"
 edition = "2021"
-description="ISO 3166-1 (Codes for the representation of names of countries and their subdivisions – Part 1: Country codes) is a standard defining codes for the names of countries, dependent territories, and special areas of geographical interest. It is the first part of the ISO 3166 standard published by the International Organization for Standardization."
-repository="https://github.com/rust-iso/rust_iso3166"
-license="Apache-2.0"
+description = "ISO 3166-1 (Codes for the representation of names of countries and their subdivisions – Part 1: Country codes) is a standard defining codes for the names of countries, dependent territories, and special areas of geographical interest. It is the first part of the ISO 3166 standard published by the International Organization for Standardization."
+repository = "https://github.com/rust-iso/rust_iso3166"
+license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 exclude = ["src/*.py"]
 documentation = "https://docs.rs/rust_iso3166/"
-keywords=["ISO3166", "ISO3166-1", "ISO3166-2", "ISO3166-3"]
+keywords = ["ISO3166", "ISO3166-1", "ISO3166-2", "ISO3166-3"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = []
+serde = ["dep:serde"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(direct_wasm)'] }
+
+
 [dependencies]
 phf = { version = "^0.11.1", features = ["macros"] }
+serde = { version = "^1.0.228", optional = true }
+
+[dev-dependencies]
+serde_json = { version = "^1.0.107" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 prettytable-rs = "^0.10"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,55 +1,49 @@
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-  use prettytable::{row, Table};
-  use std::env;
+    use prettytable::{row, Table};
+    use std::env;
 
-  let mut args = env::args();
-  let script_name = match args.next() {
-    Some(arg) => arg,
-    None => String::from(""),
-  };
-  let query = match args.next() {
-    Some(arg) => arg,
-    None => String::from(""),
-  };
-  let query = &query.to_lowercase();
+    let mut args = env::args();
+    let script_name = args.next().unwrap_or_default();
+    let query = args.next().unwrap_or_default();
+    let query = &query.to_lowercase();
 
-  eprintln!("Usage: {} [query]", script_name);
-  let mut found = false;
-  let mut table = Table::new();
-  table.add_row(row!["Name", "Alpha2", "Alpha3", "Numeric"]);
+    eprintln!("Usage: {} [query]", script_name);
+    let mut found = false;
+    let mut table = Table::new();
+    table.add_row(row!["Name", "Alpha2", "Alpha3", "Numeric"]);
 
-  for country in rust_iso3166::ALL {
-    if country.alpha2.to_lowercase().contains(query)
-      || country.alpha3.to_lowercase().contains(query)
-      || country.numeric_str().to_lowercase().contains(query)
-    {
-      table.add_row(row![
-        country.name,
-        country.alpha2,
-        country.alpha3,
-        country.numeric_str()
-      ]);
-      found = true;
-    }
-  }
-
-  if !found {
     for country in rust_iso3166::ALL {
-      if country.name.to_lowercase().contains(query) {
-        table.add_row(row![
-          country.name,
-          country.alpha2,
-          country.alpha3,
-          country.numeric_str()
-        ]);
-      }
+        if country.alpha2.to_lowercase().contains(query)
+            || country.alpha3.to_lowercase().contains(query)
+            || country.numeric_str().to_lowercase().contains(query)
+        {
+            table.add_row(row![
+                country.name,
+                country.alpha2,
+                country.alpha3,
+                country.numeric_str()
+            ]);
+            found = true;
+        }
     }
-  }
-  table.printstd();
+
+    if !found {
+        for country in rust_iso3166::ALL {
+            if country.name.to_lowercase().contains(query) {
+                table.add_row(row![
+                    country.name,
+                    country.alpha2,
+                    country.alpha3,
+                    country.numeric_str()
+                ]);
+            }
+        }
+    }
+    table.printstd();
 }
 
 #[cfg(target_arch = "wasm32")]
 fn main() {
-  unimplemented!();
+    unimplemented!();
 }

--- a/src/iso3166_3.rs
+++ b/src/iso3166_3.rs
@@ -1,14 +1,15 @@
-
+use crate::CountryCode;
+#[cfg(all(direct_wasm, target_arch = "wasm32"))]
+use js_sys::Array;
 use phf::phf_map;
 use phf::Map;
-use crate::CountryCode;
-#[cfg(all(direct_wasm,target_arch = "wasm32"))]
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+#[cfg(all(direct_wasm, target_arch = "wasm32"))]
 use wasm_bindgen::prelude::*;
-#[cfg(all(direct_wasm,target_arch = "wasm32"))]
-use js_sys::Array;
 
 /// Data for each Country Code defined by ISO 3166-1
-#[cfg(all(direct_wasm,target_arch = "wasm32"))]
+#[cfg(all(direct_wasm, target_arch = "wasm32"))]
 #[wasm_bindgen]
 #[derive(Debug, Ord, PartialOrd, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct CountryCode3 {
@@ -24,10 +25,9 @@ pub struct CountryCode3 {
     validity: &'static [i32],
     ///Decription
     desc: &'static str,
-   
 }
 
-#[cfg(all(direct_wasm,target_arch = "wasm32"))]
+#[cfg(all(direct_wasm, target_arch = "wasm32"))]
 #[wasm_bindgen]
 impl CountryCode3 {
     #[wasm_bindgen(getter)]
@@ -47,21 +47,21 @@ impl CountryCode3 {
 
     #[wasm_bindgen(getter)]
     pub fn new_countries(&self) -> Array {
-    	let mut vector: Vec<CountryCode> = Vec::new(); 
+        let mut vector: Vec<CountryCode> = Vec::new();
         // self.individual_languages.into_serde().unwrap();
-		for i in 0..self.new_countries.len() {
-			vector.push(self.new_countries[i])
-		}
-		vector.into_iter().map(JsValue::from).collect()
+        for i in 0..self.new_countries.len() {
+            vector.push(self.new_countries[i])
+        }
+        vector.into_iter().map(JsValue::from).collect()
     }
-    
+
     #[wasm_bindgen(getter)]
     pub fn desc(&self) -> String {
         self.desc.into()
     }
 }
 
-#[cfg(any(not(direct_wasm),not(target_arch = "wasm32")))]
+#[cfg(any(not(direct_wasm), not(target_arch = "wasm32")))]
 #[derive(Debug, Ord, PartialOrd, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct CountryCode3 {
     ///ISO 3166-3 code
@@ -76,9 +76,7 @@ pub struct CountryCode3 {
     pub validity: &'static [i32],
     ///Decription
     pub desc: &'static str,
-   
 }
-
 
 pub const BQAQ: CountryCode3 = CountryCode3 {
     code: "BQAQ",
@@ -89,20 +87,15 @@ pub const BQAQ: CountryCode3 = CountryCode3 {
         alpha3: "ATB",
         numeric: 0,
     },
-    validity: &[1974,1979],
+    validity: &[1974, 1979],
     desc: "Merged into Antarctica ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Antarctica",
         alpha2: "AQ",
         alpha3: "ATA",
         numeric: 10,
-},
-
-    ],
+    }],
 };
-
 
 pub const BUMM: CountryCode3 = CountryCode3 {
     code: "BUMM",
@@ -113,20 +106,15 @@ pub const BUMM: CountryCode3 = CountryCode3 {
         alpha3: "BUR",
         numeric: 104,
     },
-    validity: &[1974,1989],
+    validity: &[1974, 1989],
     desc: "Name changed to Myanmar ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Myanmar",
         alpha2: "MM",
         alpha3: "MMR",
         numeric: 104,
-},
-
-    ],
+    }],
 };
-
 
 pub const BYAA: CountryCode3 = CountryCode3 {
     code: "BYAA",
@@ -137,20 +125,15 @@ pub const BYAA: CountryCode3 = CountryCode3 {
         alpha3: "BYS",
         numeric: 112,
     },
-    validity: &[1974,1992],
+    validity: &[1974, 1992],
     desc: "Name changed to Belarus ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Belarus",
         alpha2: "BY",
         alpha3: "BLR",
         numeric: 112,
-},
-
-    ],
+    }],
 };
-
 
 pub const CTKI: CountryCode3 = CountryCode3 {
     code: "CTKI",
@@ -161,20 +144,15 @@ pub const CTKI: CountryCode3 = CountryCode3 {
         alpha3: "CTE",
         numeric: 128,
     },
-    validity: &[1974,1984],
+    validity: &[1974, 1984],
     desc: "Merged into Kiribati ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Kiribati",
         alpha2: "KI",
         alpha3: "KIR",
         numeric: 296,
-},
-
-    ],
+    }],
 };
-
 
 pub const CSHH: CountryCode3 = CountryCode3 {
     code: "CSHH",
@@ -185,26 +163,23 @@ pub const CSHH: CountryCode3 = CountryCode3 {
         alpha3: "CSK",
         numeric: 200,
     },
-    validity: &[1974,1993],
+    validity: &[1974, 1993],
     desc: "Divided into: Czechia  Slovakia ",
     new_countries: &[
-
- CountryCode {
-        name: "Czechia",
-        alpha2: "CZ",
-        alpha3: "CZE",
-        numeric: 203,
-},
- CountryCode {
-        name: "Slovakia",
-        alpha2: "SK",
-        alpha3: "SVK",
-        numeric: 703,
-},
-
+        CountryCode {
+            name: "Czechia",
+            alpha2: "CZ",
+            alpha3: "CZE",
+            numeric: 203,
+        },
+        CountryCode {
+            name: "Slovakia",
+            alpha2: "SK",
+            alpha3: "SVK",
+            numeric: 703,
+        },
     ],
 };
-
 
 pub const DYBJ: CountryCode3 = CountryCode3 {
     code: "DYBJ",
@@ -215,20 +190,15 @@ pub const DYBJ: CountryCode3 = CountryCode3 {
         alpha3: "DHY",
         numeric: 204,
     },
-    validity: &[1974,1977],
+    validity: &[1974, 1977],
     desc: "Name changed to Benin ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Benin",
         alpha2: "BJ",
         alpha3: "BEN",
         numeric: 204,
-},
-
-    ],
+    }],
 };
-
 
 pub const NQAQ: CountryCode3 = CountryCode3 {
     code: "NQAQ",
@@ -239,20 +209,15 @@ pub const NQAQ: CountryCode3 = CountryCode3 {
         alpha3: "ATN",
         numeric: 216,
     },
-    validity: &[1974,1983],
+    validity: &[1974, 1983],
     desc: "Merged into Antarctica ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Antarctica",
         alpha2: "AQ",
         alpha3: "ATA",
         numeric: 10,
-},
-
-    ],
+    }],
 };
-
 
 pub const TPTL: CountryCode3 = CountryCode3 {
     code: "TPTL",
@@ -263,20 +228,15 @@ pub const TPTL: CountryCode3 = CountryCode3 {
         alpha3: "TMP",
         numeric: 626,
     },
-    validity: &[1974,2002],
+    validity: &[1974, 2002],
     desc: "Name changed to Timor-Leste ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Timor-Leste",
         alpha2: "TL",
         alpha3: "TLS",
         numeric: 626,
-},
-
-    ],
+    }],
 };
-
 
 pub const FXFR: CountryCode3 = CountryCode3 {
     code: "FXFR",
@@ -287,20 +247,15 @@ pub const FXFR: CountryCode3 = CountryCode3 {
         alpha3: "FXX",
         numeric: 249,
     },
-    validity: &[1993,1997],
+    validity: &[1993, 1997],
     desc: "Merged into France ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "France",
         alpha2: "FR",
         alpha3: "FRA",
         numeric: 250,
-},
-
-    ],
+    }],
 };
-
 
 pub const AIDJ: CountryCode3 = CountryCode3 {
     code: "AIDJ",
@@ -311,20 +266,15 @@ pub const AIDJ: CountryCode3 = CountryCode3 {
         alpha3: "AFI",
         numeric: 262,
     },
-    validity: &[1974,1977],
+    validity: &[1974, 1977],
     desc: "Name changed to Djibouti ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Djibouti",
         alpha2: "DJ",
         alpha3: "DJI",
         numeric: 262,
-},
-
-    ],
+    }],
 };
-
 
 pub const FQHH: CountryCode3 = CountryCode3 {
     code: "FQHH",
@@ -335,26 +285,23 @@ pub const FQHH: CountryCode3 = CountryCode3 {
         alpha3: "ATF",
         numeric: 0,
     },
-    validity: &[1974,1979],
+    validity: &[1974, 1979],
     desc: "Divided into: Part of Antarctica   French Southern Territories ",
     new_countries: &[
-
- CountryCode {
-        name: "Part of Antarctica",
-        alpha2: "AQ",
-        alpha3: "ATA",
-        numeric: 10,
-},
- CountryCode {
-        name: "French Southern Territories",
-        alpha2: "TF",
-        alpha3: "ATF",
-        numeric: 260,
-},
-
+        CountryCode {
+            name: "Part of Antarctica",
+            alpha2: "AQ",
+            alpha3: "ATA",
+            numeric: 10,
+        },
+        CountryCode {
+            name: "French Southern Territories",
+            alpha2: "TF",
+            alpha3: "ATF",
+            numeric: 260,
+        },
     ],
 };
-
 
 pub const DDDE: CountryCode3 = CountryCode3 {
     code: "DDDE",
@@ -365,20 +312,15 @@ pub const DDDE: CountryCode3 = CountryCode3 {
         alpha3: "DDR",
         numeric: 278,
     },
-    validity: &[1974,1990],
+    validity: &[1974, 1990],
     desc: "Merged into Germany ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Germany",
         alpha2: "DE",
         alpha3: "DEU",
         numeric: 276,
-},
-
-    ],
+    }],
 };
-
 
 pub const GEHH: CountryCode3 = CountryCode3 {
     code: "GEHH",
@@ -389,20 +331,15 @@ pub const GEHH: CountryCode3 = CountryCode3 {
         alpha3: "GEL",
         numeric: 296,
     },
-    validity: &[1974,1979],
+    validity: &[1974, 1979],
     desc: "Name changed to Kiribati ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Kiribati",
         alpha2: "KI",
         alpha3: "KIR",
         numeric: 296,
-},
-
-    ],
+    }],
 };
-
 
 pub const JTUM: CountryCode3 = CountryCode3 {
     code: "JTUM",
@@ -413,20 +350,15 @@ pub const JTUM: CountryCode3 = CountryCode3 {
         alpha3: "JTN",
         numeric: 396,
     },
-    validity: &[1974,1986],
+    validity: &[1974, 1986],
     desc: "Merged into United States Minor Outlying Islands ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "United States Minor Outlying Islands",
         alpha2: "UM",
         alpha3: "UMI",
         numeric: 581,
-},
-
-    ],
+    }],
 };
-
 
 pub const MIUM: CountryCode3 = CountryCode3 {
     code: "MIUM",
@@ -437,20 +369,15 @@ pub const MIUM: CountryCode3 = CountryCode3 {
         alpha3: "MID",
         numeric: 488,
     },
-    validity: &[1974,1986],
+    validity: &[1974, 1986],
     desc: "Merged into United States Minor Outlying Islands ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "United States Minor Outlying Islands",
         alpha2: "UM",
         alpha3: "UMI",
         numeric: 581,
-},
-
-    ],
+    }],
 };
-
 
 pub const ANHH: CountryCode3 = CountryCode3 {
     code: "ANHH",
@@ -461,32 +388,29 @@ pub const ANHH: CountryCode3 = CountryCode3 {
         alpha3: "ANT",
         numeric: 530,
     },
-    validity: &[1974,2010 ],
+    validity: &[1974, 2010],
     desc: "Divided into: Bonaire, Sint Eustatius and Saba   Curaçao  Sint Maarten  ",
     new_countries: &[
-
- CountryCode {
-        name: "Bonaire, Sint Eustatius and Saba",
-        alpha2: "BQ",
-        alpha3: "BES",
-        numeric: 535,
-},
- CountryCode {
-        name: "Curaçao",
-        alpha2: "CW",
-        alpha3: "CUW",
-        numeric: 531,
-},
- CountryCode {
-        name: "Sint Maarten (Dutch part)",
-        alpha2: "SX",
-        alpha3: "SXM",
-        numeric: 534,
-},
-
+        CountryCode {
+            name: "Bonaire, Sint Eustatius and Saba",
+            alpha2: "BQ",
+            alpha3: "BES",
+            numeric: 535,
+        },
+        CountryCode {
+            name: "Curaçao",
+            alpha2: "CW",
+            alpha3: "CUW",
+            numeric: 531,
+        },
+        CountryCode {
+            name: "Sint Maarten (Dutch part)",
+            alpha2: "SX",
+            alpha3: "SXM",
+            numeric: 534,
+        },
     ],
 };
-
 
 pub const NTHH: CountryCode3 = CountryCode3 {
     code: "NTHH",
@@ -497,26 +421,23 @@ pub const NTHH: CountryCode3 = CountryCode3 {
         alpha3: "NTZ",
         numeric: 536,
     },
-    validity: &[1974,1993],
+    validity: &[1974, 1993],
     desc: "Divided into: Part of Iraq  Part of Saudi Arabia ",
     new_countries: &[
-
- CountryCode {
-        name: "Part of Iraq",
-        alpha2: "IQ",
-        alpha3: "IRQ",
-        numeric: 368,
-},
- CountryCode {
-        name: "Part of Saudi Arabia",
-        alpha2: "SA",
-        alpha3: "SAU",
-        numeric: 682,
-},
-
+        CountryCode {
+            name: "Part of Iraq",
+            alpha2: "IQ",
+            alpha3: "IRQ",
+            numeric: 368,
+        },
+        CountryCode {
+            name: "Part of Saudi Arabia",
+            alpha2: "SA",
+            alpha3: "SAU",
+            numeric: 682,
+        },
     ],
 };
-
 
 pub const NHVU: CountryCode3 = CountryCode3 {
     code: "NHVU",
@@ -527,20 +448,15 @@ pub const NHVU: CountryCode3 = CountryCode3 {
         alpha3: "NHB",
         numeric: 548,
     },
-    validity: &[1974,1980],
+    validity: &[1974, 1980],
     desc: "Name changed to Vanuatu ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Vanuatu",
         alpha2: "VU",
         alpha3: "VUT",
         numeric: 548,
-},
-
-    ],
+    }],
 };
-
 
 pub const PCHH: CountryCode3 = CountryCode3 {
     code: "PCHH",
@@ -551,38 +467,35 @@ pub const PCHH: CountryCode3 = CountryCode3 {
         alpha3: "PCI",
         numeric: 582,
     },
-    validity: &[1974,1986],
+    validity: &[1974, 1986],
     desc: "Divided into: Marshall Islands  Micronesia   Northern Mariana Islands  Palau ",
     new_countries: &[
-
- CountryCode {
-        name: "Marshall Islands",
-        alpha2: "MH",
-        alpha3: "MHL",
-        numeric: 584,
-},
- CountryCode {
-        name: "Micronesia (Federated States of)",
-        alpha2: "FM",
-        alpha3: "FSM",
-        numeric: 583,
-},
- CountryCode {
-        name: "Northern Mariana Islands",
-        alpha2: "MP",
-        alpha3: "MNP",
-        numeric: 580,
-},
- CountryCode {
-        name: "Palau",
-        alpha2: "PW",
-        alpha3: "PLW",
-        numeric: 585,
-},
-
+        CountryCode {
+            name: "Marshall Islands",
+            alpha2: "MH",
+            alpha3: "MHL",
+            numeric: 584,
+        },
+        CountryCode {
+            name: "Micronesia (Federated States of)",
+            alpha2: "FM",
+            alpha3: "FSM",
+            numeric: 583,
+        },
+        CountryCode {
+            name: "Northern Mariana Islands",
+            alpha2: "MP",
+            alpha3: "MNP",
+            numeric: 580,
+        },
+        CountryCode {
+            name: "Palau",
+            alpha2: "PW",
+            alpha3: "PLW",
+            numeric: 585,
+        },
     ],
 };
-
 
 pub const PZPA: CountryCode3 = CountryCode3 {
     code: "PZPA",
@@ -593,20 +506,15 @@ pub const PZPA: CountryCode3 = CountryCode3 {
         alpha3: "PCZ",
         numeric: 0,
     },
-    validity: &[1974,1980],
+    validity: &[1974, 1980],
     desc: "Merged into Panama ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Panama",
         alpha2: "PA",
         alpha3: "PAN",
         numeric: 591,
-},
-
-    ],
+    }],
 };
-
 
 pub const CSXX: CountryCode3 = CountryCode3 {
     code: "CSXX",
@@ -617,26 +525,23 @@ pub const CSXX: CountryCode3 = CountryCode3 {
         alpha3: "SCG",
         numeric: 891,
     },
-    validity: &[2003,2006],
+    validity: &[2003, 2006],
     desc: "Divided into: Montenegro  Serbia ",
     new_countries: &[
-
- CountryCode {
-        name: "Montenegro",
-        alpha2: "ME",
-        alpha3: "MNE",
-        numeric: 499,
-},
- CountryCode {
-        name: "Serbia",
-        alpha2: "RS",
-        alpha3: "SRB",
-        numeric: 688,
-},
-
+        CountryCode {
+            name: "Montenegro",
+            alpha2: "ME",
+            alpha3: "MNE",
+            numeric: 499,
+        },
+        CountryCode {
+            name: "Serbia",
+            alpha2: "RS",
+            alpha3: "SRB",
+            numeric: 688,
+        },
     ],
 };
-
 
 pub const SKIN: CountryCode3 = CountryCode3 {
     code: "SKIN",
@@ -647,20 +552,15 @@ pub const SKIN: CountryCode3 = CountryCode3 {
         alpha3: "SKM",
         numeric: 0,
     },
-    validity: &[1974,1975],
+    validity: &[1974, 1975],
     desc: "Merged into India ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "India",
         alpha2: "IN",
         alpha3: "IND",
         numeric: 356,
-},
-
-    ],
+    }],
 };
-
 
 pub const RHZW: CountryCode3 = CountryCode3 {
     code: "RHZW",
@@ -671,20 +571,15 @@ pub const RHZW: CountryCode3 = CountryCode3 {
         alpha3: "RHO",
         numeric: 716,
     },
-    validity: &[1974,1980],
+    validity: &[1974, 1980],
     desc: "Name changed to Zimbabwe ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Zimbabwe",
         alpha2: "ZW",
         alpha3: "ZWE",
         numeric: 716,
-},
-
-    ],
+    }],
 };
-
 
 pub const PUUM: CountryCode3 = CountryCode3 {
     code: "PUUM",
@@ -695,20 +590,15 @@ pub const PUUM: CountryCode3 = CountryCode3 {
         alpha3: "PUS",
         numeric: 849,
     },
-    validity: &[1974,1986],
+    validity: &[1974, 1986],
     desc: "Merged into United States Minor Outlying Islands ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "United States Minor Outlying Islands",
         alpha2: "UM",
         alpha3: "UMI",
         numeric: 581,
-},
-
-    ],
+    }],
 };
-
 
 pub const HVBF: CountryCode3 = CountryCode3 {
     code: "HVBF",
@@ -719,20 +609,15 @@ pub const HVBF: CountryCode3 = CountryCode3 {
         alpha3: "HVO",
         numeric: 854,
     },
-    validity: &[1974,1984],
+    validity: &[1974, 1984],
     desc: "Name changed to Burkina Faso ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Burkina Faso",
         alpha2: "BF",
         alpha3: "BFA",
         numeric: 854,
-},
-
-    ],
+    }],
 };
-
 
 pub const SUHH: CountryCode3 = CountryCode3 {
     code: "SUHH",
@@ -829,7 +714,6 @@ pub const SUHH: CountryCode3 = CountryCode3 {
     ],
 };
 
-
 pub const VDVN: CountryCode3 = CountryCode3 {
     code: "VDVN",
     name: "Viet-Nam, Democratic Republic of",
@@ -839,20 +723,15 @@ pub const VDVN: CountryCode3 = CountryCode3 {
         alpha3: "VDR",
         numeric: 0,
     },
-    validity: &[1974,1977],
+    validity: &[1974, 1977],
     desc: "Merged into Viet Nam ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Viet Nam",
         alpha2: "VN",
         alpha3: "VNM",
         numeric: 704,
-},
-
-    ],
+    }],
 };
-
 
 pub const WKUM: CountryCode3 = CountryCode3 {
     code: "WKUM",
@@ -863,20 +742,15 @@ pub const WKUM: CountryCode3 = CountryCode3 {
         alpha3: "WAK",
         numeric: 872,
     },
-    validity: &[1974,1986],
+    validity: &[1974, 1986],
     desc: "Merged into United States Minor Outlying Islands ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "United States Minor Outlying Islands",
         alpha2: "UM",
         alpha3: "UMI",
         numeric: 581,
-},
-
-    ],
+    }],
 };
-
 
 pub const YDYE: CountryCode3 = CountryCode3 {
     code: "YDYE",
@@ -887,20 +761,15 @@ pub const YDYE: CountryCode3 = CountryCode3 {
         alpha3: "YMD",
         numeric: 720,
     },
-    validity: &[1974,1990],
+    validity: &[1974, 1990],
     desc: "Merged into Yemen ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Yemen",
         alpha2: "YE",
         alpha3: "YEM",
         numeric: 887,
-},
-
-    ],
+    }],
 };
-
 
 pub const YUCS: CountryCode3 = CountryCode3 {
     code: "YUCS",
@@ -911,20 +780,15 @@ pub const YUCS: CountryCode3 = CountryCode3 {
         alpha3: "YUG",
         numeric: 891,
     },
-    validity: &[1974,2003],
+    validity: &[1974, 2003],
     desc: "Name changed to Serbia and Montenegro ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Serbia and Montenegro",
         alpha2: "CS",
         alpha3: "SCG",
         numeric: 891,
-},
-
-    ],
+    }],
 };
-
 
 pub const ZRCD: CountryCode3 = CountryCode3 {
     code: "ZRCD",
@@ -935,20 +799,15 @@ pub const ZRCD: CountryCode3 = CountryCode3 {
         alpha3: "ZAR",
         numeric: 180,
     },
-    validity: &[1974,1997],
+    validity: &[1974, 1997],
     desc: "Name changed to Congo, Democratic Republic of the ",
-    new_countries: &[
-
- CountryCode {
+    new_countries: &[CountryCode {
         name: "Congo, Democratic Republic of the",
         alpha2: "CD",
         alpha3: "COD",
         numeric: 180,
-},
-
-    ],
+    }],
 };
-
 
 /// Returns the CountryCode3 with the given Alpha4 code, if exists.
 /// #Sample
@@ -961,8 +820,30 @@ pub fn from_code(alpha4: &str) -> Option<CountryCode3> {
     ALPHA4_MAP.get(alpha4).cloned()
 }
 
+#[cfg(feature = "serde")]
+impl Serialize for CountryCode3 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.code)
+    }
+}
 
-///CountryCode map with  alpha4 Code key 
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for CountryCode3 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+        let s = String::deserialize(deserializer)?;
+        let s_upper = s.to_uppercase();
+        from_code(&s_upper)
+            .ok_or_else(|| D::Error::custom(format!("Invalid ISO 3166-3 code: {}", s)))
+    }
+}
+///CountryCode map with  alpha4 Code key
 pub const ALPHA4_MAP: Map<&str, CountryCode3> = phf_map! {
 
 "BQAQ" => BQAQ,
@@ -999,41 +880,8 @@ pub const ALPHA4_MAP: Map<&str, CountryCode3> = phf_map! {
 
 };
 
-
 ///ALL the Countrys struct
-pub const ALL: & [CountryCode3] = &[
-
-BQAQ,
-BUMM,
-BYAA,
-CTKI,
-CSHH,
-DYBJ,
-NQAQ,
-TPTL,
-FXFR,
-AIDJ,
-FQHH,
-DDDE,
-GEHH,
-JTUM,
-MIUM,
-ANHH,
-NTHH,
-NHVU,
-PCHH,
-PZPA,
-CSXX,
-SKIN,
-RHZW,
-PUUM,
-HVBF,
-SUHH,
-VDVN,
-WKUM,
-YDYE,
-YUCS,
-ZRCD,
-
+pub const ALL: &[CountryCode3] = &[
+    BQAQ, BUMM, BYAA, CTKI, CSHH, DYBJ, NQAQ, TPTL, FXFR, AIDJ, FQHH, DDDE, GEHH, JTUM, MIUM, ANHH,
+    NTHH, NHVU, PCHH, PZPA, CSXX, SKIN, RHZW, PUUM, HVBF, SUHH, VDVN, WKUM, YDYE, YUCS, ZRCD,
 ];
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,25 +1,26 @@
-
 use phf::phf_map;
 use phf::Map;
 pub mod iso3166_2;
 pub mod iso3166_3;
-use std::hash::Hash;
-#[cfg(all(direct_wasm,target_arch = "wasm32"))]
-use wasm_bindgen::prelude::*;
-#[cfg(all(direct_wasm,target_arch = "wasm32"))]
+#[cfg(all(direct_wasm, target_arch = "wasm32"))]
 use js_sys::Array;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::hash::Hash;
+#[cfg(all(direct_wasm, target_arch = "wasm32"))]
+use wasm_bindgen::prelude::*;
 
 /// # Sample code
 /// ```
 /// let country = rust_iso3166::from_alpha2("AU");
-/// assert_eq!("AUS", country.unwrap().alpha3); 
+/// assert_eq!("AUS", country.unwrap().alpha3);
 /// let country = rust_iso3166::from_alpha3("AUS");
 /// assert_eq!("AU", country.unwrap().alpha2);  
 /// let country = rust_iso3166::from_numeric(036);
 /// assert_eq!("AUS", country.unwrap().alpha3);   
 /// let country = rust_iso3166::from_numeric_str("036");
-/// assert_eq!("AUS", country.unwrap().alpha3); 
-/// 
+/// assert_eq!("AUS", country.unwrap().alpha3);
+///
 /// println!("{:?}", country);   
 /// println!("{:?}", rust_iso3166::ALL);
 
@@ -35,7 +36,7 @@ use js_sys::Array;
 /// ```
 
 /// Data for each Country Code defined by ISO 3166-1
-#[cfg(all(direct_wasm,target_arch = "wasm32"))]
+#[cfg(all(direct_wasm, target_arch = "wasm32"))]
 #[wasm_bindgen]
 #[derive(Debug, Ord, PartialOrd, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct CountryCode {
@@ -49,7 +50,7 @@ pub struct CountryCode {
     numeric: i32,
 }
 
-#[cfg(any(not(direct_wasm),not(target_arch = "wasm32")))]
+#[cfg(any(not(direct_wasm), not(target_arch = "wasm32")))]
 #[derive(Debug, Ord, PartialOrd, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct CountryCode {
     ///English short name
@@ -62,60 +63,82 @@ pub struct CountryCode {
     pub numeric: i32,
 }
 
-#[cfg_attr(all(direct_wasm,target_arch = "wasm32"), wasm_bindgen)]
+#[cfg_attr(all(direct_wasm, target_arch = "wasm32"), wasm_bindgen)]
 impl CountryCode {
-
-    #[cfg(all(direct_wasm,target_arch = "wasm32"))]
+    #[cfg(all(direct_wasm, target_arch = "wasm32"))]
     #[wasm_bindgen(getter)]
     pub fn name(&self) -> String {
         self.name.into()
     }
 
-    #[cfg(all(direct_wasm,target_arch = "wasm32"))]
+    #[cfg(all(direct_wasm, target_arch = "wasm32"))]
     #[wasm_bindgen(getter)]
     pub fn alpha2(&self) -> String {
         self.alpha2.into()
     }
-    
-    #[cfg(all(direct_wasm,target_arch = "wasm32"))]
+
+    #[cfg(all(direct_wasm, target_arch = "wasm32"))]
     #[wasm_bindgen(getter)]
     pub fn alpha3(&self) -> String {
         self.alpha3.into()
     }
 
-    #[cfg(all(direct_wasm,target_arch = "wasm32"))]
+    #[cfg(all(direct_wasm, target_arch = "wasm32"))]
     #[wasm_bindgen(getter)]
     pub fn numeric(&self) -> i32 {
         self.numeric
     }
 
     ///Return len 3 String for CountryCode numeric
-    pub fn numeric_str (&self) -> String {
+    pub fn numeric_str(&self) -> String {
         format!("{:03}", self.numeric)
     }
 
     ///Return Subdivision for ISO 3166-2
-    #[cfg(any(not(direct_wasm),not(target_arch = "wasm32")))]
-    pub fn subdivisions (&self) -> Option<&[iso3166_2::Subdivision]> {
+    #[cfg(any(not(direct_wasm), not(target_arch = "wasm32")))]
+    pub fn subdivisions(&self) -> Option<&[iso3166_2::Subdivision]> {
         iso3166_2::SUBDIVISION_COUNTRY_MAP.get(self.alpha2).cloned()
     }
 
-    #[cfg(all(direct_wasm,target_arch = "wasm32"))]
-    pub fn subdivisions (&self) -> Array {
+    #[cfg(all(direct_wasm, target_arch = "wasm32"))]
+    pub fn subdivisions(&self) -> Array {
         let ps = iso3166_2::SUBDIVISION_COUNTRY_MAP.get(self.alpha2).cloned();
-        let mut vector: Vec<iso3166_2::Subdivision> = Vec::new(); 
+        let mut vector: Vec<iso3166_2::Subdivision> = Vec::new();
         match ps {
             Some(p) => {
                 for i in 0..p.len() {
-			        vector.push(p[i])
-		        }
-            },
-            None => {
-
-            },
+                    vector.push(p[i])
+                }
+            }
+            None => {}
         }
 
         vector.into_iter().map(JsValue::from).collect()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for CountryCode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.alpha2)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for CountryCode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+        let s = String::deserialize(deserializer)?;
+        let s_upper = s.to_uppercase();
+        from_alpha2(&s_upper)
+            .or_else(|| from_alpha3(&s_upper))
+            .ok_or_else(|| D::Error::custom(format!("Invalid country code: {}", s)))
     }
 }
 /// Returns the CountryCode with the given Alpha2 code, if exists.
@@ -124,7 +147,7 @@ impl CountryCode {
 /// let country = rust_iso3166::from_alpha2("AU");
 /// assert_eq!("AUS", country.unwrap().alpha3);
 /// ```
-#[cfg_attr(all(direct_wasm,target_arch = "wasm32"), wasm_bindgen)]
+#[cfg_attr(all(direct_wasm, target_arch = "wasm32"), wasm_bindgen)]
 pub fn from_alpha2(alpha2: &str) -> Option<CountryCode> {
     ALPHA2_MAP.get(alpha2).cloned()
 }
@@ -135,7 +158,7 @@ pub fn from_alpha2(alpha2: &str) -> Option<CountryCode> {
 /// let country = rust_iso3166::from_alpha3("AUS");
 /// assert_eq!(036, country.unwrap().numeric);
 /// ```
-#[cfg_attr(all(direct_wasm,target_arch = "wasm32"), wasm_bindgen)]
+#[cfg_attr(all(direct_wasm, target_arch = "wasm32"), wasm_bindgen)]
 pub fn from_alpha3(alpha3: &str) -> Option<CountryCode> {
     ALPHA3_MAP.get(alpha3).cloned()
 }
@@ -146,7 +169,7 @@ pub fn from_alpha3(alpha3: &str) -> Option<CountryCode> {
 /// let country = rust_iso3166::from_numeric(036);
 /// assert_eq!("AUS", country.unwrap().alpha3);
 /// ```
-#[cfg_attr(all(direct_wasm,target_arch = "wasm32"), wasm_bindgen)]
+#[cfg_attr(all(direct_wasm, target_arch = "wasm32"), wasm_bindgen)]
 pub fn from_numeric(numeric: i32) -> Option<CountryCode> {
     let k = format!("{:03}", numeric);
     NUMERIC_MAP.get(&k).cloned()
@@ -158,12 +181,10 @@ pub fn from_numeric(numeric: i32) -> Option<CountryCode> {
 /// let country = rust_iso3166::from_numeric_str("036");
 /// assert_eq!("AUS", country.unwrap().alpha3);
 /// ```
-#[cfg_attr(all(direct_wasm,target_arch = "wasm32"), wasm_bindgen)]
+#[cfg_attr(all(direct_wasm, target_arch = "wasm32"), wasm_bindgen)]
 pub fn from_numeric_str(numeric: &str) -> Option<CountryCode> {
     NUMERIC_MAP.get(numeric).cloned()
 }
-
-
 
 pub const AF: CountryCode = CountryCode {
     name: "Afghanistan",
@@ -172,14 +193,12 @@ pub const AF: CountryCode = CountryCode {
     numeric: 4,
 };
 
-
 pub const AX: CountryCode = CountryCode {
     name: "Åland Islands",
     alpha2: "AX",
     alpha3: "ALA",
     numeric: 248,
 };
-
 
 pub const AL: CountryCode = CountryCode {
     name: "Albania",
@@ -188,14 +207,12 @@ pub const AL: CountryCode = CountryCode {
     numeric: 8,
 };
 
-
 pub const DZ: CountryCode = CountryCode {
     name: "Algeria",
     alpha2: "DZ",
     alpha3: "DZA",
     numeric: 12,
 };
-
 
 pub const AS: CountryCode = CountryCode {
     name: "American Samoa",
@@ -204,14 +221,12 @@ pub const AS: CountryCode = CountryCode {
     numeric: 16,
 };
 
-
 pub const AD: CountryCode = CountryCode {
     name: "Andorra",
     alpha2: "AD",
     alpha3: "AND",
     numeric: 20,
 };
-
 
 pub const AO: CountryCode = CountryCode {
     name: "Angola",
@@ -220,14 +235,12 @@ pub const AO: CountryCode = CountryCode {
     numeric: 24,
 };
 
-
 pub const AI: CountryCode = CountryCode {
     name: "Anguilla",
     alpha2: "AI",
     alpha3: "AIA",
     numeric: 660,
 };
-
 
 pub const AQ: CountryCode = CountryCode {
     name: "Antarctica",
@@ -236,14 +249,12 @@ pub const AQ: CountryCode = CountryCode {
     numeric: 10,
 };
 
-
 pub const AG: CountryCode = CountryCode {
     name: "Antigua and Barbuda",
     alpha2: "AG",
     alpha3: "ATG",
     numeric: 28,
 };
-
 
 pub const AR: CountryCode = CountryCode {
     name: "Argentina",
@@ -252,14 +263,12 @@ pub const AR: CountryCode = CountryCode {
     numeric: 32,
 };
 
-
 pub const AM: CountryCode = CountryCode {
     name: "Armenia",
     alpha2: "AM",
     alpha3: "ARM",
     numeric: 51,
 };
-
 
 pub const AW: CountryCode = CountryCode {
     name: "Aruba",
@@ -268,14 +277,12 @@ pub const AW: CountryCode = CountryCode {
     numeric: 533,
 };
 
-
 pub const AU: CountryCode = CountryCode {
     name: "Australia",
     alpha2: "AU",
     alpha3: "AUS",
     numeric: 36,
 };
-
 
 pub const AT: CountryCode = CountryCode {
     name: "Austria",
@@ -284,14 +291,12 @@ pub const AT: CountryCode = CountryCode {
     numeric: 40,
 };
 
-
 pub const AZ: CountryCode = CountryCode {
     name: "Azerbaijan",
     alpha2: "AZ",
     alpha3: "AZE",
     numeric: 31,
 };
-
 
 pub const BS: CountryCode = CountryCode {
     name: "Bahamas",
@@ -300,14 +305,12 @@ pub const BS: CountryCode = CountryCode {
     numeric: 44,
 };
 
-
 pub const BH: CountryCode = CountryCode {
     name: "Bahrain",
     alpha2: "BH",
     alpha3: "BHR",
     numeric: 48,
 };
-
 
 pub const BD: CountryCode = CountryCode {
     name: "Bangladesh",
@@ -316,14 +319,12 @@ pub const BD: CountryCode = CountryCode {
     numeric: 50,
 };
 
-
 pub const BB: CountryCode = CountryCode {
     name: "Barbados",
     alpha2: "BB",
     alpha3: "BRB",
     numeric: 52,
 };
-
 
 pub const BY: CountryCode = CountryCode {
     name: "Belarus",
@@ -332,14 +333,12 @@ pub const BY: CountryCode = CountryCode {
     numeric: 112,
 };
 
-
 pub const BE: CountryCode = CountryCode {
     name: "Belgium",
     alpha2: "BE",
     alpha3: "BEL",
     numeric: 56,
 };
-
 
 pub const BZ: CountryCode = CountryCode {
     name: "Belize",
@@ -348,14 +347,12 @@ pub const BZ: CountryCode = CountryCode {
     numeric: 84,
 };
 
-
 pub const BJ: CountryCode = CountryCode {
     name: "Benin",
     alpha2: "BJ",
     alpha3: "BEN",
     numeric: 204,
 };
-
 
 pub const BM: CountryCode = CountryCode {
     name: "Bermuda",
@@ -364,14 +361,12 @@ pub const BM: CountryCode = CountryCode {
     numeric: 60,
 };
 
-
 pub const BT: CountryCode = CountryCode {
     name: "Bhutan",
     alpha2: "BT",
     alpha3: "BTN",
     numeric: 64,
 };
-
 
 pub const BO: CountryCode = CountryCode {
     name: "Bolivia (Plurinational State of)",
@@ -380,14 +375,12 @@ pub const BO: CountryCode = CountryCode {
     numeric: 68,
 };
 
-
 pub const BQ: CountryCode = CountryCode {
     name: "Bonaire, Sint Eustatius and Saba[c]",
     alpha2: "BQ",
     alpha3: "BES",
     numeric: 535,
 };
-
 
 pub const BA: CountryCode = CountryCode {
     name: "Bosnia and Herzegovina",
@@ -396,14 +389,12 @@ pub const BA: CountryCode = CountryCode {
     numeric: 70,
 };
 
-
 pub const BW: CountryCode = CountryCode {
     name: "Botswana",
     alpha2: "BW",
     alpha3: "BWA",
     numeric: 72,
 };
-
 
 pub const BV: CountryCode = CountryCode {
     name: "Bouvet Island",
@@ -412,14 +403,12 @@ pub const BV: CountryCode = CountryCode {
     numeric: 74,
 };
 
-
 pub const BR: CountryCode = CountryCode {
     name: "Brazil",
     alpha2: "BR",
     alpha3: "BRA",
     numeric: 76,
 };
-
 
 pub const IO: CountryCode = CountryCode {
     name: "British Indian Ocean Territory",
@@ -428,14 +417,12 @@ pub const IO: CountryCode = CountryCode {
     numeric: 86,
 };
 
-
 pub const BN: CountryCode = CountryCode {
     name: "Brunei Darussalam",
     alpha2: "BN",
     alpha3: "BRN",
     numeric: 96,
 };
-
 
 pub const BG: CountryCode = CountryCode {
     name: "Bulgaria",
@@ -444,14 +431,12 @@ pub const BG: CountryCode = CountryCode {
     numeric: 100,
 };
 
-
 pub const BF: CountryCode = CountryCode {
     name: "Burkina Faso",
     alpha2: "BF",
     alpha3: "BFA",
     numeric: 854,
 };
-
 
 pub const BI: CountryCode = CountryCode {
     name: "Burundi",
@@ -460,14 +445,12 @@ pub const BI: CountryCode = CountryCode {
     numeric: 108,
 };
 
-
 pub const CV: CountryCode = CountryCode {
     name: "Cabo Verde",
     alpha2: "CV",
     alpha3: "CPV",
     numeric: 132,
 };
-
 
 pub const KH: CountryCode = CountryCode {
     name: "Cambodia",
@@ -476,14 +459,12 @@ pub const KH: CountryCode = CountryCode {
     numeric: 116,
 };
 
-
 pub const CM: CountryCode = CountryCode {
     name: "Cameroon",
     alpha2: "CM",
     alpha3: "CMR",
     numeric: 120,
 };
-
 
 pub const CA: CountryCode = CountryCode {
     name: "Canada",
@@ -492,14 +473,12 @@ pub const CA: CountryCode = CountryCode {
     numeric: 124,
 };
 
-
 pub const KY: CountryCode = CountryCode {
     name: "Cayman Islands",
     alpha2: "KY",
     alpha3: "CYM",
     numeric: 136,
 };
-
 
 pub const CF: CountryCode = CountryCode {
     name: "Central African Republic",
@@ -508,14 +487,12 @@ pub const CF: CountryCode = CountryCode {
     numeric: 140,
 };
 
-
 pub const TD: CountryCode = CountryCode {
     name: "Chad",
     alpha2: "TD",
     alpha3: "TCD",
     numeric: 148,
 };
-
 
 pub const CL: CountryCode = CountryCode {
     name: "Chile",
@@ -524,14 +501,12 @@ pub const CL: CountryCode = CountryCode {
     numeric: 152,
 };
 
-
 pub const CN: CountryCode = CountryCode {
     name: "China",
     alpha2: "CN",
     alpha3: "CHN",
     numeric: 156,
 };
-
 
 pub const CX: CountryCode = CountryCode {
     name: "Christmas Island",
@@ -540,14 +515,12 @@ pub const CX: CountryCode = CountryCode {
     numeric: 162,
 };
 
-
 pub const CC: CountryCode = CountryCode {
     name: "Cocos (Keeling) Islands",
     alpha2: "CC",
     alpha3: "CCK",
     numeric: 166,
 };
-
 
 pub const CO: CountryCode = CountryCode {
     name: "Colombia",
@@ -556,14 +529,12 @@ pub const CO: CountryCode = CountryCode {
     numeric: 170,
 };
 
-
 pub const KM: CountryCode = CountryCode {
     name: "Comoros",
     alpha2: "KM",
     alpha3: "COM",
     numeric: 174,
 };
-
 
 pub const CG: CountryCode = CountryCode {
     name: "Congo",
@@ -572,14 +543,12 @@ pub const CG: CountryCode = CountryCode {
     numeric: 178,
 };
 
-
 pub const CD: CountryCode = CountryCode {
     name: "Congo, Democratic Republic of the",
     alpha2: "CD",
     alpha3: "COD",
     numeric: 180,
 };
-
 
 pub const CK: CountryCode = CountryCode {
     name: "Cook Islands",
@@ -588,14 +557,12 @@ pub const CK: CountryCode = CountryCode {
     numeric: 184,
 };
 
-
 pub const CR: CountryCode = CountryCode {
     name: "Costa Rica",
     alpha2: "CR",
     alpha3: "CRI",
     numeric: 188,
 };
-
 
 pub const CI: CountryCode = CountryCode {
     name: "Côte d'Ivoire",
@@ -604,14 +571,12 @@ pub const CI: CountryCode = CountryCode {
     numeric: 384,
 };
 
-
 pub const HR: CountryCode = CountryCode {
     name: "Croatia",
     alpha2: "HR",
     alpha3: "HRV",
     numeric: 191,
 };
-
 
 pub const CU: CountryCode = CountryCode {
     name: "Cuba",
@@ -620,14 +585,12 @@ pub const CU: CountryCode = CountryCode {
     numeric: 192,
 };
 
-
 pub const CW: CountryCode = CountryCode {
     name: "Curaçao",
     alpha2: "CW",
     alpha3: "CUW",
     numeric: 531,
 };
-
 
 pub const CY: CountryCode = CountryCode {
     name: "Cyprus",
@@ -636,14 +599,12 @@ pub const CY: CountryCode = CountryCode {
     numeric: 196,
 };
 
-
 pub const CZ: CountryCode = CountryCode {
     name: "Czechia",
     alpha2: "CZ",
     alpha3: "CZE",
     numeric: 203,
 };
-
 
 pub const DK: CountryCode = CountryCode {
     name: "Denmark",
@@ -652,14 +613,12 @@ pub const DK: CountryCode = CountryCode {
     numeric: 208,
 };
 
-
 pub const DJ: CountryCode = CountryCode {
     name: "Djibouti",
     alpha2: "DJ",
     alpha3: "DJI",
     numeric: 262,
 };
-
 
 pub const DM: CountryCode = CountryCode {
     name: "Dominica",
@@ -668,14 +627,12 @@ pub const DM: CountryCode = CountryCode {
     numeric: 212,
 };
 
-
 pub const DO: CountryCode = CountryCode {
     name: "Dominican Republic",
     alpha2: "DO",
     alpha3: "DOM",
     numeric: 214,
 };
-
 
 pub const EC: CountryCode = CountryCode {
     name: "Ecuador",
@@ -684,14 +641,12 @@ pub const EC: CountryCode = CountryCode {
     numeric: 218,
 };
 
-
 pub const EG: CountryCode = CountryCode {
     name: "Egypt",
     alpha2: "EG",
     alpha3: "EGY",
     numeric: 818,
 };
-
 
 pub const SV: CountryCode = CountryCode {
     name: "El Salvador",
@@ -700,14 +655,12 @@ pub const SV: CountryCode = CountryCode {
     numeric: 222,
 };
 
-
 pub const GQ: CountryCode = CountryCode {
     name: "Equatorial Guinea",
     alpha2: "GQ",
     alpha3: "GNQ",
     numeric: 226,
 };
-
 
 pub const ER: CountryCode = CountryCode {
     name: "Eritrea",
@@ -716,14 +669,12 @@ pub const ER: CountryCode = CountryCode {
     numeric: 232,
 };
 
-
 pub const EE: CountryCode = CountryCode {
     name: "Estonia",
     alpha2: "EE",
     alpha3: "EST",
     numeric: 233,
 };
-
 
 pub const SZ: CountryCode = CountryCode {
     name: "Eswatini",
@@ -732,14 +683,12 @@ pub const SZ: CountryCode = CountryCode {
     numeric: 748,
 };
 
-
 pub const ET: CountryCode = CountryCode {
     name: "Ethiopia",
     alpha2: "ET",
     alpha3: "ETH",
     numeric: 231,
 };
-
 
 pub const FK: CountryCode = CountryCode {
     name: "Falkland Islands (Malvinas)",
@@ -748,14 +697,12 @@ pub const FK: CountryCode = CountryCode {
     numeric: 238,
 };
 
-
 pub const FO: CountryCode = CountryCode {
     name: "Faroe Islands",
     alpha2: "FO",
     alpha3: "FRO",
     numeric: 234,
 };
-
 
 pub const FJ: CountryCode = CountryCode {
     name: "Fiji",
@@ -764,14 +711,12 @@ pub const FJ: CountryCode = CountryCode {
     numeric: 242,
 };
 
-
 pub const FI: CountryCode = CountryCode {
     name: "Finland",
     alpha2: "FI",
     alpha3: "FIN",
     numeric: 246,
 };
-
 
 pub const FR: CountryCode = CountryCode {
     name: "France",
@@ -780,14 +725,12 @@ pub const FR: CountryCode = CountryCode {
     numeric: 250,
 };
 
-
 pub const GF: CountryCode = CountryCode {
     name: "French Guiana",
     alpha2: "GF",
     alpha3: "GUF",
     numeric: 254,
 };
-
 
 pub const PF: CountryCode = CountryCode {
     name: "French Polynesia",
@@ -796,14 +739,12 @@ pub const PF: CountryCode = CountryCode {
     numeric: 258,
 };
 
-
 pub const TF: CountryCode = CountryCode {
     name: "French Southern Territories",
     alpha2: "TF",
     alpha3: "ATF",
     numeric: 260,
 };
-
 
 pub const GA: CountryCode = CountryCode {
     name: "Gabon",
@@ -812,14 +753,12 @@ pub const GA: CountryCode = CountryCode {
     numeric: 266,
 };
 
-
 pub const GM: CountryCode = CountryCode {
     name: "Gambia",
     alpha2: "GM",
     alpha3: "GMB",
     numeric: 270,
 };
-
 
 pub const GE: CountryCode = CountryCode {
     name: "Georgia",
@@ -828,14 +767,12 @@ pub const GE: CountryCode = CountryCode {
     numeric: 268,
 };
 
-
 pub const DE: CountryCode = CountryCode {
     name: "Germany",
     alpha2: "DE",
     alpha3: "DEU",
     numeric: 276,
 };
-
 
 pub const GH: CountryCode = CountryCode {
     name: "Ghana",
@@ -844,14 +781,12 @@ pub const GH: CountryCode = CountryCode {
     numeric: 288,
 };
 
-
 pub const GI: CountryCode = CountryCode {
     name: "Gibraltar",
     alpha2: "GI",
     alpha3: "GIB",
     numeric: 292,
 };
-
 
 pub const GR: CountryCode = CountryCode {
     name: "Greece",
@@ -860,14 +795,12 @@ pub const GR: CountryCode = CountryCode {
     numeric: 300,
 };
 
-
 pub const GL: CountryCode = CountryCode {
     name: "Greenland",
     alpha2: "GL",
     alpha3: "GRL",
     numeric: 304,
 };
-
 
 pub const GD: CountryCode = CountryCode {
     name: "Grenada",
@@ -876,14 +809,12 @@ pub const GD: CountryCode = CountryCode {
     numeric: 308,
 };
 
-
 pub const GP: CountryCode = CountryCode {
     name: "Guadeloupe",
     alpha2: "GP",
     alpha3: "GLP",
     numeric: 312,
 };
-
 
 pub const GU: CountryCode = CountryCode {
     name: "Guam",
@@ -892,14 +823,12 @@ pub const GU: CountryCode = CountryCode {
     numeric: 316,
 };
 
-
 pub const GT: CountryCode = CountryCode {
     name: "Guatemala",
     alpha2: "GT",
     alpha3: "GTM",
     numeric: 320,
 };
-
 
 pub const GG: CountryCode = CountryCode {
     name: "Guernsey",
@@ -908,14 +837,12 @@ pub const GG: CountryCode = CountryCode {
     numeric: 831,
 };
 
-
 pub const GN: CountryCode = CountryCode {
     name: "Guinea",
     alpha2: "GN",
     alpha3: "GIN",
     numeric: 324,
 };
-
 
 pub const GW: CountryCode = CountryCode {
     name: "Guinea-Bissau",
@@ -924,14 +851,12 @@ pub const GW: CountryCode = CountryCode {
     numeric: 624,
 };
 
-
 pub const GY: CountryCode = CountryCode {
     name: "Guyana",
     alpha2: "GY",
     alpha3: "GUY",
     numeric: 328,
 };
-
 
 pub const HT: CountryCode = CountryCode {
     name: "Haiti",
@@ -940,14 +865,12 @@ pub const HT: CountryCode = CountryCode {
     numeric: 332,
 };
 
-
 pub const HM: CountryCode = CountryCode {
     name: "Heard Island and McDonald Islands",
     alpha2: "HM",
     alpha3: "HMD",
     numeric: 334,
 };
-
 
 pub const VA: CountryCode = CountryCode {
     name: "Holy See",
@@ -956,14 +879,12 @@ pub const VA: CountryCode = CountryCode {
     numeric: 336,
 };
 
-
 pub const HN: CountryCode = CountryCode {
     name: "Honduras",
     alpha2: "HN",
     alpha3: "HND",
     numeric: 340,
 };
-
 
 pub const HK: CountryCode = CountryCode {
     name: "Hong Kong",
@@ -972,14 +893,12 @@ pub const HK: CountryCode = CountryCode {
     numeric: 344,
 };
 
-
 pub const HU: CountryCode = CountryCode {
     name: "Hungary",
     alpha2: "HU",
     alpha3: "HUN",
     numeric: 348,
 };
-
 
 pub const IS: CountryCode = CountryCode {
     name: "Iceland",
@@ -988,14 +907,12 @@ pub const IS: CountryCode = CountryCode {
     numeric: 352,
 };
 
-
 pub const IN: CountryCode = CountryCode {
     name: "India",
     alpha2: "IN",
     alpha3: "IND",
     numeric: 356,
 };
-
 
 pub const ID: CountryCode = CountryCode {
     name: "Indonesia",
@@ -1004,14 +921,12 @@ pub const ID: CountryCode = CountryCode {
     numeric: 360,
 };
 
-
 pub const IR: CountryCode = CountryCode {
     name: "Iran (Islamic Republic of)",
     alpha2: "IR",
     alpha3: "IRN",
     numeric: 364,
 };
-
 
 pub const IQ: CountryCode = CountryCode {
     name: "Iraq",
@@ -1020,14 +935,12 @@ pub const IQ: CountryCode = CountryCode {
     numeric: 368,
 };
 
-
 pub const IE: CountryCode = CountryCode {
     name: "Ireland",
     alpha2: "IE",
     alpha3: "IRL",
     numeric: 372,
 };
-
 
 pub const IM: CountryCode = CountryCode {
     name: "Isle of Man",
@@ -1036,14 +949,12 @@ pub const IM: CountryCode = CountryCode {
     numeric: 833,
 };
 
-
 pub const IL: CountryCode = CountryCode {
     name: "Israel",
     alpha2: "IL",
     alpha3: "ISR",
     numeric: 376,
 };
-
 
 pub const IT: CountryCode = CountryCode {
     name: "Italy",
@@ -1052,14 +963,12 @@ pub const IT: CountryCode = CountryCode {
     numeric: 380,
 };
 
-
 pub const JM: CountryCode = CountryCode {
     name: "Jamaica",
     alpha2: "JM",
     alpha3: "JAM",
     numeric: 388,
 };
-
 
 pub const JP: CountryCode = CountryCode {
     name: "Japan",
@@ -1068,14 +977,12 @@ pub const JP: CountryCode = CountryCode {
     numeric: 392,
 };
 
-
 pub const JE: CountryCode = CountryCode {
     name: "Jersey",
     alpha2: "JE",
     alpha3: "JEY",
     numeric: 832,
 };
-
 
 pub const JO: CountryCode = CountryCode {
     name: "Jordan",
@@ -1084,14 +991,12 @@ pub const JO: CountryCode = CountryCode {
     numeric: 400,
 };
 
-
 pub const KZ: CountryCode = CountryCode {
     name: "Kazakhstan",
     alpha2: "KZ",
     alpha3: "KAZ",
     numeric: 398,
 };
-
 
 pub const KE: CountryCode = CountryCode {
     name: "Kenya",
@@ -1100,14 +1005,12 @@ pub const KE: CountryCode = CountryCode {
     numeric: 404,
 };
 
-
 pub const KI: CountryCode = CountryCode {
     name: "Kiribati",
     alpha2: "KI",
     alpha3: "KIR",
     numeric: 296,
 };
-
 
 pub const KP: CountryCode = CountryCode {
     name: "Korea (Democratic People's Republic of)",
@@ -1116,14 +1019,12 @@ pub const KP: CountryCode = CountryCode {
     numeric: 408,
 };
 
-
 pub const KR: CountryCode = CountryCode {
     name: "Korea, Republic of",
     alpha2: "KR",
     alpha3: "KOR",
     numeric: 410,
 };
-
 
 pub const KW: CountryCode = CountryCode {
     name: "Kuwait",
@@ -1132,14 +1033,12 @@ pub const KW: CountryCode = CountryCode {
     numeric: 414,
 };
 
-
 pub const KG: CountryCode = CountryCode {
     name: "Kyrgyzstan",
     alpha2: "KG",
     alpha3: "KGZ",
     numeric: 417,
 };
-
 
 pub const LA: CountryCode = CountryCode {
     name: "Lao People's Democratic Republic",
@@ -1148,14 +1047,12 @@ pub const LA: CountryCode = CountryCode {
     numeric: 418,
 };
 
-
 pub const LV: CountryCode = CountryCode {
     name: "Latvia",
     alpha2: "LV",
     alpha3: "LVA",
     numeric: 428,
 };
-
 
 pub const LB: CountryCode = CountryCode {
     name: "Lebanon",
@@ -1164,14 +1061,12 @@ pub const LB: CountryCode = CountryCode {
     numeric: 422,
 };
 
-
 pub const LS: CountryCode = CountryCode {
     name: "Lesotho",
     alpha2: "LS",
     alpha3: "LSO",
     numeric: 426,
 };
-
 
 pub const LR: CountryCode = CountryCode {
     name: "Liberia",
@@ -1180,14 +1075,12 @@ pub const LR: CountryCode = CountryCode {
     numeric: 430,
 };
 
-
 pub const LY: CountryCode = CountryCode {
     name: "Libya",
     alpha2: "LY",
     alpha3: "LBY",
     numeric: 434,
 };
-
 
 pub const LI: CountryCode = CountryCode {
     name: "Liechtenstein",
@@ -1196,14 +1089,12 @@ pub const LI: CountryCode = CountryCode {
     numeric: 438,
 };
 
-
 pub const LT: CountryCode = CountryCode {
     name: "Lithuania",
     alpha2: "LT",
     alpha3: "LTU",
     numeric: 440,
 };
-
 
 pub const LU: CountryCode = CountryCode {
     name: "Luxembourg",
@@ -1212,14 +1103,12 @@ pub const LU: CountryCode = CountryCode {
     numeric: 442,
 };
 
-
 pub const MO: CountryCode = CountryCode {
     name: "Macao",
     alpha2: "MO",
     alpha3: "MAC",
     numeric: 446,
 };
-
 
 pub const MG: CountryCode = CountryCode {
     name: "Madagascar",
@@ -1228,14 +1117,12 @@ pub const MG: CountryCode = CountryCode {
     numeric: 450,
 };
 
-
 pub const MW: CountryCode = CountryCode {
     name: "Malawi",
     alpha2: "MW",
     alpha3: "MWI",
     numeric: 454,
 };
-
 
 pub const MY: CountryCode = CountryCode {
     name: "Malaysia",
@@ -1244,14 +1131,12 @@ pub const MY: CountryCode = CountryCode {
     numeric: 458,
 };
 
-
 pub const MV: CountryCode = CountryCode {
     name: "Maldives",
     alpha2: "MV",
     alpha3: "MDV",
     numeric: 462,
 };
-
 
 pub const ML: CountryCode = CountryCode {
     name: "Mali",
@@ -1260,14 +1145,12 @@ pub const ML: CountryCode = CountryCode {
     numeric: 466,
 };
 
-
 pub const MT: CountryCode = CountryCode {
     name: "Malta",
     alpha2: "MT",
     alpha3: "MLT",
     numeric: 470,
 };
-
 
 pub const MH: CountryCode = CountryCode {
     name: "Marshall Islands",
@@ -1276,14 +1159,12 @@ pub const MH: CountryCode = CountryCode {
     numeric: 584,
 };
 
-
 pub const MQ: CountryCode = CountryCode {
     name: "Martinique",
     alpha2: "MQ",
     alpha3: "MTQ",
     numeric: 474,
 };
-
 
 pub const MR: CountryCode = CountryCode {
     name: "Mauritania",
@@ -1292,14 +1173,12 @@ pub const MR: CountryCode = CountryCode {
     numeric: 478,
 };
 
-
 pub const MU: CountryCode = CountryCode {
     name: "Mauritius",
     alpha2: "MU",
     alpha3: "MUS",
     numeric: 480,
 };
-
 
 pub const YT: CountryCode = CountryCode {
     name: "Mayotte",
@@ -1308,14 +1187,12 @@ pub const YT: CountryCode = CountryCode {
     numeric: 175,
 };
 
-
 pub const MX: CountryCode = CountryCode {
     name: "Mexico",
     alpha2: "MX",
     alpha3: "MEX",
     numeric: 484,
 };
-
 
 pub const FM: CountryCode = CountryCode {
     name: "Micronesia (Federated States of)",
@@ -1324,14 +1201,12 @@ pub const FM: CountryCode = CountryCode {
     numeric: 583,
 };
 
-
 pub const MD: CountryCode = CountryCode {
     name: "Moldova, Republic of",
     alpha2: "MD",
     alpha3: "MDA",
     numeric: 498,
 };
-
 
 pub const MC: CountryCode = CountryCode {
     name: "Monaco",
@@ -1340,14 +1215,12 @@ pub const MC: CountryCode = CountryCode {
     numeric: 492,
 };
 
-
 pub const MN: CountryCode = CountryCode {
     name: "Mongolia",
     alpha2: "MN",
     alpha3: "MNG",
     numeric: 496,
 };
-
 
 pub const ME: CountryCode = CountryCode {
     name: "Montenegro",
@@ -1356,14 +1229,12 @@ pub const ME: CountryCode = CountryCode {
     numeric: 499,
 };
 
-
 pub const MS: CountryCode = CountryCode {
     name: "Montserrat",
     alpha2: "MS",
     alpha3: "MSR",
     numeric: 500,
 };
-
 
 pub const MA: CountryCode = CountryCode {
     name: "Morocco",
@@ -1372,14 +1243,12 @@ pub const MA: CountryCode = CountryCode {
     numeric: 504,
 };
 
-
 pub const MZ: CountryCode = CountryCode {
     name: "Mozambique",
     alpha2: "MZ",
     alpha3: "MOZ",
     numeric: 508,
 };
-
 
 pub const MM: CountryCode = CountryCode {
     name: "Myanmar",
@@ -1388,14 +1257,12 @@ pub const MM: CountryCode = CountryCode {
     numeric: 104,
 };
 
-
 pub const NA: CountryCode = CountryCode {
     name: "Namibia",
     alpha2: "NA",
     alpha3: "NAM",
     numeric: 516,
 };
-
 
 pub const NR: CountryCode = CountryCode {
     name: "Nauru",
@@ -1404,14 +1271,12 @@ pub const NR: CountryCode = CountryCode {
     numeric: 520,
 };
 
-
 pub const NP: CountryCode = CountryCode {
     name: "Nepal",
     alpha2: "NP",
     alpha3: "NPL",
     numeric: 524,
 };
-
 
 pub const NL: CountryCode = CountryCode {
     name: "Netherlands",
@@ -1420,14 +1285,12 @@ pub const NL: CountryCode = CountryCode {
     numeric: 528,
 };
 
-
 pub const NC: CountryCode = CountryCode {
     name: "New Caledonia",
     alpha2: "NC",
     alpha3: "NCL",
     numeric: 540,
 };
-
 
 pub const NZ: CountryCode = CountryCode {
     name: "New Zealand",
@@ -1436,14 +1299,12 @@ pub const NZ: CountryCode = CountryCode {
     numeric: 554,
 };
 
-
 pub const NI: CountryCode = CountryCode {
     name: "Nicaragua",
     alpha2: "NI",
     alpha3: "NIC",
     numeric: 558,
 };
-
 
 pub const NE: CountryCode = CountryCode {
     name: "Niger",
@@ -1452,14 +1313,12 @@ pub const NE: CountryCode = CountryCode {
     numeric: 562,
 };
 
-
 pub const NG: CountryCode = CountryCode {
     name: "Nigeria",
     alpha2: "NG",
     alpha3: "NGA",
     numeric: 566,
 };
-
 
 pub const NU: CountryCode = CountryCode {
     name: "Niue",
@@ -1468,14 +1327,12 @@ pub const NU: CountryCode = CountryCode {
     numeric: 570,
 };
 
-
 pub const NF: CountryCode = CountryCode {
     name: "Norfolk Island",
     alpha2: "NF",
     alpha3: "NFK",
     numeric: 574,
 };
-
 
 pub const MK: CountryCode = CountryCode {
     name: "North Macedonia",
@@ -1484,14 +1341,12 @@ pub const MK: CountryCode = CountryCode {
     numeric: 807,
 };
 
-
 pub const MP: CountryCode = CountryCode {
     name: "Northern Mariana Islands",
     alpha2: "MP",
     alpha3: "MNP",
     numeric: 580,
 };
-
 
 pub const NO: CountryCode = CountryCode {
     name: "Norway",
@@ -1500,14 +1355,12 @@ pub const NO: CountryCode = CountryCode {
     numeric: 578,
 };
 
-
 pub const OM: CountryCode = CountryCode {
     name: "Oman",
     alpha2: "OM",
     alpha3: "OMN",
     numeric: 512,
 };
-
 
 pub const PK: CountryCode = CountryCode {
     name: "Pakistan",
@@ -1516,14 +1369,12 @@ pub const PK: CountryCode = CountryCode {
     numeric: 586,
 };
 
-
 pub const PW: CountryCode = CountryCode {
     name: "Palau",
     alpha2: "PW",
     alpha3: "PLW",
     numeric: 585,
 };
-
 
 pub const PS: CountryCode = CountryCode {
     name: "Palestine, State of",
@@ -1532,14 +1383,12 @@ pub const PS: CountryCode = CountryCode {
     numeric: 275,
 };
 
-
 pub const PA: CountryCode = CountryCode {
     name: "Panama",
     alpha2: "PA",
     alpha3: "PAN",
     numeric: 591,
 };
-
 
 pub const PG: CountryCode = CountryCode {
     name: "Papua New Guinea",
@@ -1548,14 +1397,12 @@ pub const PG: CountryCode = CountryCode {
     numeric: 598,
 };
 
-
 pub const PY: CountryCode = CountryCode {
     name: "Paraguay",
     alpha2: "PY",
     alpha3: "PRY",
     numeric: 600,
 };
-
 
 pub const PE: CountryCode = CountryCode {
     name: "Peru",
@@ -1564,14 +1411,12 @@ pub const PE: CountryCode = CountryCode {
     numeric: 604,
 };
 
-
 pub const PH: CountryCode = CountryCode {
     name: "Philippines",
     alpha2: "PH",
     alpha3: "PHL",
     numeric: 608,
 };
-
 
 pub const PN: CountryCode = CountryCode {
     name: "Pitcairn",
@@ -1580,14 +1425,12 @@ pub const PN: CountryCode = CountryCode {
     numeric: 612,
 };
 
-
 pub const PL: CountryCode = CountryCode {
     name: "Poland",
     alpha2: "PL",
     alpha3: "POL",
     numeric: 616,
 };
-
 
 pub const PT: CountryCode = CountryCode {
     name: "Portugal",
@@ -1596,14 +1439,12 @@ pub const PT: CountryCode = CountryCode {
     numeric: 620,
 };
 
-
 pub const PR: CountryCode = CountryCode {
     name: "Puerto Rico",
     alpha2: "PR",
     alpha3: "PRI",
     numeric: 630,
 };
-
 
 pub const QA: CountryCode = CountryCode {
     name: "Qatar",
@@ -1612,14 +1453,12 @@ pub const QA: CountryCode = CountryCode {
     numeric: 634,
 };
 
-
 pub const RE: CountryCode = CountryCode {
     name: "Réunion",
     alpha2: "RE",
     alpha3: "REU",
     numeric: 638,
 };
-
 
 pub const RO: CountryCode = CountryCode {
     name: "Romania",
@@ -1628,14 +1467,12 @@ pub const RO: CountryCode = CountryCode {
     numeric: 642,
 };
 
-
 pub const RU: CountryCode = CountryCode {
     name: "Russian Federation",
     alpha2: "RU",
     alpha3: "RUS",
     numeric: 643,
 };
-
 
 pub const RW: CountryCode = CountryCode {
     name: "Rwanda",
@@ -1644,14 +1481,12 @@ pub const RW: CountryCode = CountryCode {
     numeric: 646,
 };
 
-
 pub const BL: CountryCode = CountryCode {
     name: "Saint Barthélemy",
     alpha2: "BL",
     alpha3: "BLM",
     numeric: 652,
 };
-
 
 pub const SH: CountryCode = CountryCode {
     name: "Saint Helena, Ascension and Tristan da Cunha[d]",
@@ -1660,14 +1495,12 @@ pub const SH: CountryCode = CountryCode {
     numeric: 654,
 };
 
-
 pub const KN: CountryCode = CountryCode {
     name: "Saint Kitts and Nevis",
     alpha2: "KN",
     alpha3: "KNA",
     numeric: 659,
 };
-
 
 pub const LC: CountryCode = CountryCode {
     name: "Saint Lucia",
@@ -1676,14 +1509,12 @@ pub const LC: CountryCode = CountryCode {
     numeric: 662,
 };
 
-
 pub const MF: CountryCode = CountryCode {
     name: "Saint Martin (French part)",
     alpha2: "MF",
     alpha3: "MAF",
     numeric: 663,
 };
-
 
 pub const PM: CountryCode = CountryCode {
     name: "Saint Pierre and Miquelon",
@@ -1692,14 +1523,12 @@ pub const PM: CountryCode = CountryCode {
     numeric: 666,
 };
 
-
 pub const VC: CountryCode = CountryCode {
     name: "Saint Vincent and the Grenadines",
     alpha2: "VC",
     alpha3: "VCT",
     numeric: 670,
 };
-
 
 pub const WS: CountryCode = CountryCode {
     name: "Samoa",
@@ -1708,14 +1537,12 @@ pub const WS: CountryCode = CountryCode {
     numeric: 882,
 };
 
-
 pub const SM: CountryCode = CountryCode {
     name: "San Marino",
     alpha2: "SM",
     alpha3: "SMR",
     numeric: 674,
 };
-
 
 pub const ST: CountryCode = CountryCode {
     name: "Sao Tome and Principe",
@@ -1724,14 +1551,12 @@ pub const ST: CountryCode = CountryCode {
     numeric: 678,
 };
 
-
 pub const SA: CountryCode = CountryCode {
     name: "Saudi Arabia",
     alpha2: "SA",
     alpha3: "SAU",
     numeric: 682,
 };
-
 
 pub const SN: CountryCode = CountryCode {
     name: "Senegal",
@@ -1740,14 +1565,12 @@ pub const SN: CountryCode = CountryCode {
     numeric: 686,
 };
 
-
 pub const RS: CountryCode = CountryCode {
     name: "Serbia",
     alpha2: "RS",
     alpha3: "SRB",
     numeric: 688,
 };
-
 
 pub const SC: CountryCode = CountryCode {
     name: "Seychelles",
@@ -1756,14 +1579,12 @@ pub const SC: CountryCode = CountryCode {
     numeric: 690,
 };
 
-
 pub const SL: CountryCode = CountryCode {
     name: "Sierra Leone",
     alpha2: "SL",
     alpha3: "SLE",
     numeric: 694,
 };
-
 
 pub const SG: CountryCode = CountryCode {
     name: "Singapore",
@@ -1772,14 +1593,12 @@ pub const SG: CountryCode = CountryCode {
     numeric: 702,
 };
 
-
 pub const SX: CountryCode = CountryCode {
     name: "Sint Maarten (Dutch part)",
     alpha2: "SX",
     alpha3: "SXM",
     numeric: 534,
 };
-
 
 pub const SK: CountryCode = CountryCode {
     name: "Slovakia",
@@ -1788,14 +1607,12 @@ pub const SK: CountryCode = CountryCode {
     numeric: 703,
 };
 
-
 pub const SI: CountryCode = CountryCode {
     name: "Slovenia",
     alpha2: "SI",
     alpha3: "SVN",
     numeric: 705,
 };
-
 
 pub const SB: CountryCode = CountryCode {
     name: "Solomon Islands",
@@ -1804,14 +1621,12 @@ pub const SB: CountryCode = CountryCode {
     numeric: 90,
 };
 
-
 pub const SO: CountryCode = CountryCode {
     name: "Somalia",
     alpha2: "SO",
     alpha3: "SOM",
     numeric: 706,
 };
-
 
 pub const ZA: CountryCode = CountryCode {
     name: "South Africa",
@@ -1820,14 +1635,12 @@ pub const ZA: CountryCode = CountryCode {
     numeric: 710,
 };
 
-
 pub const GS: CountryCode = CountryCode {
     name: "South Georgia and the South Sandwich Islands",
     alpha2: "GS",
     alpha3: "SGS",
     numeric: 239,
 };
-
 
 pub const SS: CountryCode = CountryCode {
     name: "South Sudan",
@@ -1836,14 +1649,12 @@ pub const SS: CountryCode = CountryCode {
     numeric: 728,
 };
 
-
 pub const ES: CountryCode = CountryCode {
     name: "Spain",
     alpha2: "ES",
     alpha3: "ESP",
     numeric: 724,
 };
-
 
 pub const LK: CountryCode = CountryCode {
     name: "Sri Lanka",
@@ -1852,14 +1663,12 @@ pub const LK: CountryCode = CountryCode {
     numeric: 144,
 };
 
-
 pub const SD: CountryCode = CountryCode {
     name: "Sudan",
     alpha2: "SD",
     alpha3: "SDN",
     numeric: 729,
 };
-
 
 pub const SR: CountryCode = CountryCode {
     name: "Suriname",
@@ -1868,14 +1677,12 @@ pub const SR: CountryCode = CountryCode {
     numeric: 740,
 };
 
-
 pub const SJ: CountryCode = CountryCode {
     name: "Svalbard and Jan Mayen[e]",
     alpha2: "SJ",
     alpha3: "SJM",
     numeric: 744,
 };
-
 
 pub const SE: CountryCode = CountryCode {
     name: "Sweden",
@@ -1884,14 +1691,12 @@ pub const SE: CountryCode = CountryCode {
     numeric: 752,
 };
 
-
 pub const CH: CountryCode = CountryCode {
     name: "Switzerland",
     alpha2: "CH",
     alpha3: "CHE",
     numeric: 756,
 };
-
 
 pub const SY: CountryCode = CountryCode {
     name: "Syrian Arab Republic",
@@ -1900,14 +1705,12 @@ pub const SY: CountryCode = CountryCode {
     numeric: 760,
 };
 
-
 pub const TW: CountryCode = CountryCode {
     name: "Taiwan, Province of China",
     alpha2: "TW",
     alpha3: "TWN",
     numeric: 158,
 };
-
 
 pub const TJ: CountryCode = CountryCode {
     name: "Tajikistan",
@@ -1916,14 +1719,12 @@ pub const TJ: CountryCode = CountryCode {
     numeric: 762,
 };
 
-
 pub const TZ: CountryCode = CountryCode {
     name: "Tanzania, United Republic of",
     alpha2: "TZ",
     alpha3: "TZA",
     numeric: 834,
 };
-
 
 pub const TH: CountryCode = CountryCode {
     name: "Thailand",
@@ -1932,14 +1733,12 @@ pub const TH: CountryCode = CountryCode {
     numeric: 764,
 };
 
-
 pub const TL: CountryCode = CountryCode {
     name: "Timor-Leste",
     alpha2: "TL",
     alpha3: "TLS",
     numeric: 626,
 };
-
 
 pub const TG: CountryCode = CountryCode {
     name: "Togo",
@@ -1948,14 +1747,12 @@ pub const TG: CountryCode = CountryCode {
     numeric: 768,
 };
 
-
 pub const TK: CountryCode = CountryCode {
     name: "Tokelau",
     alpha2: "TK",
     alpha3: "TKL",
     numeric: 772,
 };
-
 
 pub const TO: CountryCode = CountryCode {
     name: "Tonga",
@@ -1964,14 +1761,12 @@ pub const TO: CountryCode = CountryCode {
     numeric: 776,
 };
 
-
 pub const TT: CountryCode = CountryCode {
     name: "Trinidad and Tobago",
     alpha2: "TT",
     alpha3: "TTO",
     numeric: 780,
 };
-
 
 pub const TN: CountryCode = CountryCode {
     name: "Tunisia",
@@ -1980,14 +1775,12 @@ pub const TN: CountryCode = CountryCode {
     numeric: 788,
 };
 
-
 pub const TR: CountryCode = CountryCode {
     name: "Turkey",
     alpha2: "TR",
     alpha3: "TUR",
     numeric: 792,
 };
-
 
 pub const TM: CountryCode = CountryCode {
     name: "Turkmenistan",
@@ -1996,14 +1789,12 @@ pub const TM: CountryCode = CountryCode {
     numeric: 795,
 };
 
-
 pub const TC: CountryCode = CountryCode {
     name: "Turks and Caicos Islands",
     alpha2: "TC",
     alpha3: "TCA",
     numeric: 796,
 };
-
 
 pub const TV: CountryCode = CountryCode {
     name: "Tuvalu",
@@ -2012,14 +1803,12 @@ pub const TV: CountryCode = CountryCode {
     numeric: 798,
 };
 
-
 pub const UG: CountryCode = CountryCode {
     name: "Uganda",
     alpha2: "UG",
     alpha3: "UGA",
     numeric: 800,
 };
-
 
 pub const UA: CountryCode = CountryCode {
     name: "Ukraine",
@@ -2028,14 +1817,12 @@ pub const UA: CountryCode = CountryCode {
     numeric: 804,
 };
 
-
 pub const AE: CountryCode = CountryCode {
     name: "United Arab Emirates",
     alpha2: "AE",
     alpha3: "ARE",
     numeric: 784,
 };
-
 
 pub const GB: CountryCode = CountryCode {
     name: "United Kingdom of Great Britain and Northern Ireland",
@@ -2044,14 +1831,12 @@ pub const GB: CountryCode = CountryCode {
     numeric: 826,
 };
 
-
 pub const US: CountryCode = CountryCode {
     name: "United States of America",
     alpha2: "US",
     alpha3: "USA",
     numeric: 840,
 };
-
 
 pub const UM: CountryCode = CountryCode {
     name: "United States Minor Outlying Islands[f]",
@@ -2060,14 +1845,12 @@ pub const UM: CountryCode = CountryCode {
     numeric: 581,
 };
 
-
 pub const UY: CountryCode = CountryCode {
     name: "Uruguay",
     alpha2: "UY",
     alpha3: "URY",
     numeric: 858,
 };
-
 
 pub const UZ: CountryCode = CountryCode {
     name: "Uzbekistan",
@@ -2076,14 +1859,12 @@ pub const UZ: CountryCode = CountryCode {
     numeric: 860,
 };
 
-
 pub const VU: CountryCode = CountryCode {
     name: "Vanuatu",
     alpha2: "VU",
     alpha3: "VUT",
     numeric: 548,
 };
-
 
 pub const VE: CountryCode = CountryCode {
     name: "Venezuela (Bolivarian Republic of)",
@@ -2092,14 +1873,12 @@ pub const VE: CountryCode = CountryCode {
     numeric: 862,
 };
 
-
 pub const VN: CountryCode = CountryCode {
     name: "Viet Nam",
     alpha2: "VN",
     alpha3: "VNM",
     numeric: 704,
 };
-
 
 pub const VG: CountryCode = CountryCode {
     name: "Virgin Islands (British)",
@@ -2108,14 +1887,12 @@ pub const VG: CountryCode = CountryCode {
     numeric: 92,
 };
 
-
 pub const VI: CountryCode = CountryCode {
     name: "Virgin Islands (U.S.)",
     alpha2: "VI",
     alpha3: "VIR",
     numeric: 850,
 };
-
 
 pub const WF: CountryCode = CountryCode {
     name: "Wallis and Futuna",
@@ -2124,14 +1901,12 @@ pub const WF: CountryCode = CountryCode {
     numeric: 876,
 };
 
-
 pub const EH: CountryCode = CountryCode {
     name: "Western Sahara",
     alpha2: "EH",
     alpha3: "ESH",
     numeric: 732,
 };
-
 
 pub const YE: CountryCode = CountryCode {
     name: "Yemen",
@@ -2140,14 +1915,12 @@ pub const YE: CountryCode = CountryCode {
     numeric: 887,
 };
 
-
 pub const ZM: CountryCode = CountryCode {
     name: "Zambia",
     alpha2: "ZM",
     alpha3: "ZMB",
     numeric: 894,
 };
-
 
 pub const ZW: CountryCode = CountryCode {
     name: "Zimbabwe",
@@ -2156,9 +1929,7 @@ pub const ZW: CountryCode = CountryCode {
     numeric: 716,
 };
 
-
-
-///CountryCode map with  alpha2 Code key 
+///CountryCode map with  alpha2 Code key
 pub const ALPHA2_MAP: Map<&str, CountryCode> = phf_map! {
 
 
@@ -2415,8 +2186,7 @@ pub const ALPHA2_MAP: Map<&str, CountryCode> = phf_map! {
 
 };
 
-
-///CountryCode map with  alpha3 Code key 
+///CountryCode map with  alpha3 Code key
 pub const ALPHA3_MAP: Map<&str, CountryCode> = phf_map! {
 
 
@@ -2673,8 +2443,7 @@ pub const ALPHA3_MAP: Map<&str, CountryCode> = phf_map! {
 
 };
 
-
-///CountryCode map with  3 len numeric str Code key 
+///CountryCode map with  3 len numeric str Code key
 pub const NUMERIC_MAP: Map<&str, CountryCode> = phf_map! {
 
 
@@ -2931,1551 +2700,355 @@ pub const NUMERIC_MAP: Map<&str, CountryCode> = phf_map! {
 
 };
 
-
 ///ALL the names of Countrys
-pub const ALL_NAME: & [&str] = &[
-
-
-"Afghanistan",
-"Åland Islands",
-"Albania",
-"Algeria",
-"American Samoa",
-"Andorra",
-"Angola",
-"Anguilla",
-"Antarctica",
-"Antigua and Barbuda",
-"Argentina",
-"Armenia",
-"Aruba",
-"Australia",
-"Austria",
-"Azerbaijan",
-"Bahamas",
-"Bahrain",
-"Bangladesh",
-"Barbados",
-"Belarus",
-"Belgium",
-"Belize",
-"Benin",
-"Bermuda",
-"Bhutan",
-"Bolivia (Plurinational State of)",
-"Bonaire, Sint Eustatius and Saba[c]",
-"Bosnia and Herzegovina",
-"Botswana",
-"Bouvet Island",
-"Brazil",
-"British Indian Ocean Territory",
-"Brunei Darussalam",
-"Bulgaria",
-"Burkina Faso",
-"Burundi",
-"Cabo Verde",
-"Cambodia",
-"Cameroon",
-"Canada",
-"Cayman Islands",
-"Central African Republic",
-"Chad",
-"Chile",
-"China",
-"Christmas Island",
-"Cocos (Keeling) Islands",
-"Colombia",
-"Comoros",
-"Congo",
-"Congo, Democratic Republic of the",
-"Cook Islands",
-"Costa Rica",
-"Côte d'Ivoire",
-"Croatia",
-"Cuba",
-"Curaçao",
-"Cyprus",
-"Czechia",
-"Denmark",
-"Djibouti",
-"Dominica",
-"Dominican Republic",
-"Ecuador",
-"Egypt",
-"El Salvador",
-"Equatorial Guinea",
-"Eritrea",
-"Estonia",
-"Eswatini",
-"Ethiopia",
-"Falkland Islands (Malvinas)",
-"Faroe Islands",
-"Fiji",
-"Finland",
-"France",
-"French Guiana",
-"French Polynesia",
-"French Southern Territories",
-"Gabon",
-"Gambia",
-"Georgia",
-"Germany",
-"Ghana",
-"Gibraltar",
-"Greece",
-"Greenland",
-"Grenada",
-"Guadeloupe",
-"Guam",
-"Guatemala",
-"Guernsey",
-"Guinea",
-"Guinea-Bissau",
-"Guyana",
-"Haiti",
-"Heard Island and McDonald Islands",
-"Holy See",
-"Honduras",
-"Hong Kong",
-"Hungary",
-"Iceland",
-"India",
-"Indonesia",
-"Iran (Islamic Republic of)",
-"Iraq",
-"Ireland",
-"Isle of Man",
-"Israel",
-"Italy",
-"Jamaica",
-"Japan",
-"Jersey",
-"Jordan",
-"Kazakhstan",
-"Kenya",
-"Kiribati",
-"Korea (Democratic People's Republic of)",
-"Korea, Republic of",
-"Kuwait",
-"Kyrgyzstan",
-"Lao People's Democratic Republic",
-"Latvia",
-"Lebanon",
-"Lesotho",
-"Liberia",
-"Libya",
-"Liechtenstein",
-"Lithuania",
-"Luxembourg",
-"Macao",
-"Madagascar",
-"Malawi",
-"Malaysia",
-"Maldives",
-"Mali",
-"Malta",
-"Marshall Islands",
-"Martinique",
-"Mauritania",
-"Mauritius",
-"Mayotte",
-"Mexico",
-"Micronesia (Federated States of)",
-"Moldova, Republic of",
-"Monaco",
-"Mongolia",
-"Montenegro",
-"Montserrat",
-"Morocco",
-"Mozambique",
-"Myanmar",
-"Namibia",
-"Nauru",
-"Nepal",
-"Netherlands",
-"New Caledonia",
-"New Zealand",
-"Nicaragua",
-"Niger",
-"Nigeria",
-"Niue",
-"Norfolk Island",
-"North Macedonia",
-"Northern Mariana Islands",
-"Norway",
-"Oman",
-"Pakistan",
-"Palau",
-"Palestine, State of",
-"Panama",
-"Papua New Guinea",
-"Paraguay",
-"Peru",
-"Philippines",
-"Pitcairn",
-"Poland",
-"Portugal",
-"Puerto Rico",
-"Qatar",
-"Réunion",
-"Romania",
-"Russian Federation",
-"Rwanda",
-"Saint Barthélemy",
-"Saint Helena, Ascension and Tristan da Cunha[d]",
-"Saint Kitts and Nevis",
-"Saint Lucia",
-"Saint Martin (French part)",
-"Saint Pierre and Miquelon",
-"Saint Vincent and the Grenadines",
-"Samoa",
-"San Marino",
-"Sao Tome and Principe",
-"Saudi Arabia",
-"Senegal",
-"Serbia",
-"Seychelles",
-"Sierra Leone",
-"Singapore",
-"Sint Maarten (Dutch part)",
-"Slovakia",
-"Slovenia",
-"Solomon Islands",
-"Somalia",
-"South Africa",
-"South Georgia and the South Sandwich Islands",
-"South Sudan",
-"Spain",
-"Sri Lanka",
-"Sudan",
-"Suriname",
-"Svalbard and Jan Mayen[e]",
-"Sweden",
-"Switzerland",
-"Syrian Arab Republic",
-"Taiwan, Province of China",
-"Tajikistan",
-"Tanzania, United Republic of",
-"Thailand",
-"Timor-Leste",
-"Togo",
-"Tokelau",
-"Tonga",
-"Trinidad and Tobago",
-"Tunisia",
-"Turkey",
-"Turkmenistan",
-"Turks and Caicos Islands",
-"Tuvalu",
-"Uganda",
-"Ukraine",
-"United Arab Emirates",
-"United Kingdom of Great Britain and Northern Ireland",
-"United States of America",
-"United States Minor Outlying Islands[f]",
-"Uruguay",
-"Uzbekistan",
-"Vanuatu",
-"Venezuela (Bolivarian Republic of)",
-"Viet Nam",
-"Virgin Islands (British)",
-"Virgin Islands (U.S.)",
-"Wallis and Futuna",
-"Western Sahara",
-"Yemen",
-"Zambia",
-"Zimbabwe",
-
-
+pub const ALL_NAME: &[&str] = &[
+    "Afghanistan",
+    "Åland Islands",
+    "Albania",
+    "Algeria",
+    "American Samoa",
+    "Andorra",
+    "Angola",
+    "Anguilla",
+    "Antarctica",
+    "Antigua and Barbuda",
+    "Argentina",
+    "Armenia",
+    "Aruba",
+    "Australia",
+    "Austria",
+    "Azerbaijan",
+    "Bahamas",
+    "Bahrain",
+    "Bangladesh",
+    "Barbados",
+    "Belarus",
+    "Belgium",
+    "Belize",
+    "Benin",
+    "Bermuda",
+    "Bhutan",
+    "Bolivia (Plurinational State of)",
+    "Bonaire, Sint Eustatius and Saba[c]",
+    "Bosnia and Herzegovina",
+    "Botswana",
+    "Bouvet Island",
+    "Brazil",
+    "British Indian Ocean Territory",
+    "Brunei Darussalam",
+    "Bulgaria",
+    "Burkina Faso",
+    "Burundi",
+    "Cabo Verde",
+    "Cambodia",
+    "Cameroon",
+    "Canada",
+    "Cayman Islands",
+    "Central African Republic",
+    "Chad",
+    "Chile",
+    "China",
+    "Christmas Island",
+    "Cocos (Keeling) Islands",
+    "Colombia",
+    "Comoros",
+    "Congo",
+    "Congo, Democratic Republic of the",
+    "Cook Islands",
+    "Costa Rica",
+    "Côte d'Ivoire",
+    "Croatia",
+    "Cuba",
+    "Curaçao",
+    "Cyprus",
+    "Czechia",
+    "Denmark",
+    "Djibouti",
+    "Dominica",
+    "Dominican Republic",
+    "Ecuador",
+    "Egypt",
+    "El Salvador",
+    "Equatorial Guinea",
+    "Eritrea",
+    "Estonia",
+    "Eswatini",
+    "Ethiopia",
+    "Falkland Islands (Malvinas)",
+    "Faroe Islands",
+    "Fiji",
+    "Finland",
+    "France",
+    "French Guiana",
+    "French Polynesia",
+    "French Southern Territories",
+    "Gabon",
+    "Gambia",
+    "Georgia",
+    "Germany",
+    "Ghana",
+    "Gibraltar",
+    "Greece",
+    "Greenland",
+    "Grenada",
+    "Guadeloupe",
+    "Guam",
+    "Guatemala",
+    "Guernsey",
+    "Guinea",
+    "Guinea-Bissau",
+    "Guyana",
+    "Haiti",
+    "Heard Island and McDonald Islands",
+    "Holy See",
+    "Honduras",
+    "Hong Kong",
+    "Hungary",
+    "Iceland",
+    "India",
+    "Indonesia",
+    "Iran (Islamic Republic of)",
+    "Iraq",
+    "Ireland",
+    "Isle of Man",
+    "Israel",
+    "Italy",
+    "Jamaica",
+    "Japan",
+    "Jersey",
+    "Jordan",
+    "Kazakhstan",
+    "Kenya",
+    "Kiribati",
+    "Korea (Democratic People's Republic of)",
+    "Korea, Republic of",
+    "Kuwait",
+    "Kyrgyzstan",
+    "Lao People's Democratic Republic",
+    "Latvia",
+    "Lebanon",
+    "Lesotho",
+    "Liberia",
+    "Libya",
+    "Liechtenstein",
+    "Lithuania",
+    "Luxembourg",
+    "Macao",
+    "Madagascar",
+    "Malawi",
+    "Malaysia",
+    "Maldives",
+    "Mali",
+    "Malta",
+    "Marshall Islands",
+    "Martinique",
+    "Mauritania",
+    "Mauritius",
+    "Mayotte",
+    "Mexico",
+    "Micronesia (Federated States of)",
+    "Moldova, Republic of",
+    "Monaco",
+    "Mongolia",
+    "Montenegro",
+    "Montserrat",
+    "Morocco",
+    "Mozambique",
+    "Myanmar",
+    "Namibia",
+    "Nauru",
+    "Nepal",
+    "Netherlands",
+    "New Caledonia",
+    "New Zealand",
+    "Nicaragua",
+    "Niger",
+    "Nigeria",
+    "Niue",
+    "Norfolk Island",
+    "North Macedonia",
+    "Northern Mariana Islands",
+    "Norway",
+    "Oman",
+    "Pakistan",
+    "Palau",
+    "Palestine, State of",
+    "Panama",
+    "Papua New Guinea",
+    "Paraguay",
+    "Peru",
+    "Philippines",
+    "Pitcairn",
+    "Poland",
+    "Portugal",
+    "Puerto Rico",
+    "Qatar",
+    "Réunion",
+    "Romania",
+    "Russian Federation",
+    "Rwanda",
+    "Saint Barthélemy",
+    "Saint Helena, Ascension and Tristan da Cunha[d]",
+    "Saint Kitts and Nevis",
+    "Saint Lucia",
+    "Saint Martin (French part)",
+    "Saint Pierre and Miquelon",
+    "Saint Vincent and the Grenadines",
+    "Samoa",
+    "San Marino",
+    "Sao Tome and Principe",
+    "Saudi Arabia",
+    "Senegal",
+    "Serbia",
+    "Seychelles",
+    "Sierra Leone",
+    "Singapore",
+    "Sint Maarten (Dutch part)",
+    "Slovakia",
+    "Slovenia",
+    "Solomon Islands",
+    "Somalia",
+    "South Africa",
+    "South Georgia and the South Sandwich Islands",
+    "South Sudan",
+    "Spain",
+    "Sri Lanka",
+    "Sudan",
+    "Suriname",
+    "Svalbard and Jan Mayen[e]",
+    "Sweden",
+    "Switzerland",
+    "Syrian Arab Republic",
+    "Taiwan, Province of China",
+    "Tajikistan",
+    "Tanzania, United Republic of",
+    "Thailand",
+    "Timor-Leste",
+    "Togo",
+    "Tokelau",
+    "Tonga",
+    "Trinidad and Tobago",
+    "Tunisia",
+    "Turkey",
+    "Turkmenistan",
+    "Turks and Caicos Islands",
+    "Tuvalu",
+    "Uganda",
+    "Ukraine",
+    "United Arab Emirates",
+    "United Kingdom of Great Britain and Northern Ireland",
+    "United States of America",
+    "United States Minor Outlying Islands[f]",
+    "Uruguay",
+    "Uzbekistan",
+    "Vanuatu",
+    "Venezuela (Bolivarian Republic of)",
+    "Viet Nam",
+    "Virgin Islands (British)",
+    "Virgin Islands (U.S.)",
+    "Wallis and Futuna",
+    "Western Sahara",
+    "Yemen",
+    "Zambia",
+    "Zimbabwe",
 ];
-
 
 ///ALL the alpha2 codes of Countrys
-pub const ALL_ALPHA2: & [&str] = &[
-
-
-"AF",
-"AX",
-"AL",
-"DZ",
-"AS",
-"AD",
-"AO",
-"AI",
-"AQ",
-"AG",
-"AR",
-"AM",
-"AW",
-"AU",
-"AT",
-"AZ",
-"BS",
-"BH",
-"BD",
-"BB",
-"BY",
-"BE",
-"BZ",
-"BJ",
-"BM",
-"BT",
-"BO",
-"BQ",
-"BA",
-"BW",
-"BV",
-"BR",
-"IO",
-"BN",
-"BG",
-"BF",
-"BI",
-"CV",
-"KH",
-"CM",
-"CA",
-"KY",
-"CF",
-"TD",
-"CL",
-"CN",
-"CX",
-"CC",
-"CO",
-"KM",
-"CG",
-"CD",
-"CK",
-"CR",
-"CI",
-"HR",
-"CU",
-"CW",
-"CY",
-"CZ",
-"DK",
-"DJ",
-"DM",
-"DO",
-"EC",
-"EG",
-"SV",
-"GQ",
-"ER",
-"EE",
-"SZ",
-"ET",
-"FK",
-"FO",
-"FJ",
-"FI",
-"FR",
-"GF",
-"PF",
-"TF",
-"GA",
-"GM",
-"GE",
-"DE",
-"GH",
-"GI",
-"GR",
-"GL",
-"GD",
-"GP",
-"GU",
-"GT",
-"GG",
-"GN",
-"GW",
-"GY",
-"HT",
-"HM",
-"VA",
-"HN",
-"HK",
-"HU",
-"IS",
-"IN",
-"ID",
-"IR",
-"IQ",
-"IE",
-"IM",
-"IL",
-"IT",
-"JM",
-"JP",
-"JE",
-"JO",
-"KZ",
-"KE",
-"KI",
-"KP",
-"KR",
-"KW",
-"KG",
-"LA",
-"LV",
-"LB",
-"LS",
-"LR",
-"LY",
-"LI",
-"LT",
-"LU",
-"MO",
-"MG",
-"MW",
-"MY",
-"MV",
-"ML",
-"MT",
-"MH",
-"MQ",
-"MR",
-"MU",
-"YT",
-"MX",
-"FM",
-"MD",
-"MC",
-"MN",
-"ME",
-"MS",
-"MA",
-"MZ",
-"MM",
-"NA",
-"NR",
-"NP",
-"NL",
-"NC",
-"NZ",
-"NI",
-"NE",
-"NG",
-"NU",
-"NF",
-"MK",
-"MP",
-"NO",
-"OM",
-"PK",
-"PW",
-"PS",
-"PA",
-"PG",
-"PY",
-"PE",
-"PH",
-"PN",
-"PL",
-"PT",
-"PR",
-"QA",
-"RE",
-"RO",
-"RU",
-"RW",
-"BL",
-"SH",
-"KN",
-"LC",
-"MF",
-"PM",
-"VC",
-"WS",
-"SM",
-"ST",
-"SA",
-"SN",
-"RS",
-"SC",
-"SL",
-"SG",
-"SX",
-"SK",
-"SI",
-"SB",
-"SO",
-"ZA",
-"GS",
-"SS",
-"ES",
-"LK",
-"SD",
-"SR",
-"SJ",
-"SE",
-"CH",
-"SY",
-"TW",
-"TJ",
-"TZ",
-"TH",
-"TL",
-"TG",
-"TK",
-"TO",
-"TT",
-"TN",
-"TR",
-"TM",
-"TC",
-"TV",
-"UG",
-"UA",
-"AE",
-"GB",
-"US",
-"UM",
-"UY",
-"UZ",
-"VU",
-"VE",
-"VN",
-"VG",
-"VI",
-"WF",
-"EH",
-"YE",
-"ZM",
-"ZW",
-
-
+pub const ALL_ALPHA2: &[&str] = &[
+    "AF", "AX", "AL", "DZ", "AS", "AD", "AO", "AI", "AQ", "AG", "AR", "AM", "AW", "AU", "AT", "AZ",
+    "BS", "BH", "BD", "BB", "BY", "BE", "BZ", "BJ", "BM", "BT", "BO", "BQ", "BA", "BW", "BV", "BR",
+    "IO", "BN", "BG", "BF", "BI", "CV", "KH", "CM", "CA", "KY", "CF", "TD", "CL", "CN", "CX", "CC",
+    "CO", "KM", "CG", "CD", "CK", "CR", "CI", "HR", "CU", "CW", "CY", "CZ", "DK", "DJ", "DM", "DO",
+    "EC", "EG", "SV", "GQ", "ER", "EE", "SZ", "ET", "FK", "FO", "FJ", "FI", "FR", "GF", "PF", "TF",
+    "GA", "GM", "GE", "DE", "GH", "GI", "GR", "GL", "GD", "GP", "GU", "GT", "GG", "GN", "GW", "GY",
+    "HT", "HM", "VA", "HN", "HK", "HU", "IS", "IN", "ID", "IR", "IQ", "IE", "IM", "IL", "IT", "JM",
+    "JP", "JE", "JO", "KZ", "KE", "KI", "KP", "KR", "KW", "KG", "LA", "LV", "LB", "LS", "LR", "LY",
+    "LI", "LT", "LU", "MO", "MG", "MW", "MY", "MV", "ML", "MT", "MH", "MQ", "MR", "MU", "YT", "MX",
+    "FM", "MD", "MC", "MN", "ME", "MS", "MA", "MZ", "MM", "NA", "NR", "NP", "NL", "NC", "NZ", "NI",
+    "NE", "NG", "NU", "NF", "MK", "MP", "NO", "OM", "PK", "PW", "PS", "PA", "PG", "PY", "PE", "PH",
+    "PN", "PL", "PT", "PR", "QA", "RE", "RO", "RU", "RW", "BL", "SH", "KN", "LC", "MF", "PM", "VC",
+    "WS", "SM", "ST", "SA", "SN", "RS", "SC", "SL", "SG", "SX", "SK", "SI", "SB", "SO", "ZA", "GS",
+    "SS", "ES", "LK", "SD", "SR", "SJ", "SE", "CH", "SY", "TW", "TJ", "TZ", "TH", "TL", "TG", "TK",
+    "TO", "TT", "TN", "TR", "TM", "TC", "TV", "UG", "UA", "AE", "GB", "US", "UM", "UY", "UZ", "VU",
+    "VE", "VN", "VG", "VI", "WF", "EH", "YE", "ZM", "ZW",
 ];
-
 
 ///ALL the alpha3 codes of Countrys
-pub const ALL_ALPHA3: & [&str] = &[
-
-
-"AFG",
-"ALA",
-"ALB",
-"DZA",
-"ASM",
-"AND",
-"AGO",
-"AIA",
-"ATA",
-"ATG",
-"ARG",
-"ARM",
-"ABW",
-"AUS",
-"AUT",
-"AZE",
-"BHS",
-"BHR",
-"BGD",
-"BRB",
-"BLR",
-"BEL",
-"BLZ",
-"BEN",
-"BMU",
-"BTN",
-"BOL",
-"BES",
-"BIH",
-"BWA",
-"BVT",
-"BRA",
-"IOT",
-"BRN",
-"BGR",
-"BFA",
-"BDI",
-"CPV",
-"KHM",
-"CMR",
-"CAN",
-"CYM",
-"CAF",
-"TCD",
-"CHL",
-"CHN",
-"CXR",
-"CCK",
-"COL",
-"COM",
-"COG",
-"COD",
-"COK",
-"CRI",
-"CIV",
-"HRV",
-"CUB",
-"CUW",
-"CYP",
-"CZE",
-"DNK",
-"DJI",
-"DMA",
-"DOM",
-"ECU",
-"EGY",
-"SLV",
-"GNQ",
-"ERI",
-"EST",
-"SWZ",
-"ETH",
-"FLK",
-"FRO",
-"FJI",
-"FIN",
-"FRA",
-"GUF",
-"PYF",
-"ATF",
-"GAB",
-"GMB",
-"GEO",
-"DEU",
-"GHA",
-"GIB",
-"GRC",
-"GRL",
-"GRD",
-"GLP",
-"GUM",
-"GTM",
-"GGY",
-"GIN",
-"GNB",
-"GUY",
-"HTI",
-"HMD",
-"VAT",
-"HND",
-"HKG",
-"HUN",
-"ISL",
-"IND",
-"IDN",
-"IRN",
-"IRQ",
-"IRL",
-"IMN",
-"ISR",
-"ITA",
-"JAM",
-"JPN",
-"JEY",
-"JOR",
-"KAZ",
-"KEN",
-"KIR",
-"PRK",
-"KOR",
-"KWT",
-"KGZ",
-"LAO",
-"LVA",
-"LBN",
-"LSO",
-"LBR",
-"LBY",
-"LIE",
-"LTU",
-"LUX",
-"MAC",
-"MDG",
-"MWI",
-"MYS",
-"MDV",
-"MLI",
-"MLT",
-"MHL",
-"MTQ",
-"MRT",
-"MUS",
-"MYT",
-"MEX",
-"FSM",
-"MDA",
-"MCO",
-"MNG",
-"MNE",
-"MSR",
-"MAR",
-"MOZ",
-"MMR",
-"NAM",
-"NRU",
-"NPL",
-"NLD",
-"NCL",
-"NZL",
-"NIC",
-"NER",
-"NGA",
-"NIU",
-"NFK",
-"MKD",
-"MNP",
-"NOR",
-"OMN",
-"PAK",
-"PLW",
-"PSE",
-"PAN",
-"PNG",
-"PRY",
-"PER",
-"PHL",
-"PCN",
-"POL",
-"PRT",
-"PRI",
-"QAT",
-"REU",
-"ROU",
-"RUS",
-"RWA",
-"BLM",
-"SHN",
-"KNA",
-"LCA",
-"MAF",
-"SPM",
-"VCT",
-"WSM",
-"SMR",
-"STP",
-"SAU",
-"SEN",
-"SRB",
-"SYC",
-"SLE",
-"SGP",
-"SXM",
-"SVK",
-"SVN",
-"SLB",
-"SOM",
-"ZAF",
-"SGS",
-"SSD",
-"ESP",
-"LKA",
-"SDN",
-"SUR",
-"SJM",
-"SWE",
-"CHE",
-"SYR",
-"TWN",
-"TJK",
-"TZA",
-"THA",
-"TLS",
-"TGO",
-"TKL",
-"TON",
-"TTO",
-"TUN",
-"TUR",
-"TKM",
-"TCA",
-"TUV",
-"UGA",
-"UKR",
-"ARE",
-"GBR",
-"USA",
-"UMI",
-"URY",
-"UZB",
-"VUT",
-"VEN",
-"VNM",
-"VGB",
-"VIR",
-"WLF",
-"ESH",
-"YEM",
-"ZMB",
-"ZWE",
-
-
+pub const ALL_ALPHA3: &[&str] = &[
+    "AFG", "ALA", "ALB", "DZA", "ASM", "AND", "AGO", "AIA", "ATA", "ATG", "ARG", "ARM", "ABW",
+    "AUS", "AUT", "AZE", "BHS", "BHR", "BGD", "BRB", "BLR", "BEL", "BLZ", "BEN", "BMU", "BTN",
+    "BOL", "BES", "BIH", "BWA", "BVT", "BRA", "IOT", "BRN", "BGR", "BFA", "BDI", "CPV", "KHM",
+    "CMR", "CAN", "CYM", "CAF", "TCD", "CHL", "CHN", "CXR", "CCK", "COL", "COM", "COG", "COD",
+    "COK", "CRI", "CIV", "HRV", "CUB", "CUW", "CYP", "CZE", "DNK", "DJI", "DMA", "DOM", "ECU",
+    "EGY", "SLV", "GNQ", "ERI", "EST", "SWZ", "ETH", "FLK", "FRO", "FJI", "FIN", "FRA", "GUF",
+    "PYF", "ATF", "GAB", "GMB", "GEO", "DEU", "GHA", "GIB", "GRC", "GRL", "GRD", "GLP", "GUM",
+    "GTM", "GGY", "GIN", "GNB", "GUY", "HTI", "HMD", "VAT", "HND", "HKG", "HUN", "ISL", "IND",
+    "IDN", "IRN", "IRQ", "IRL", "IMN", "ISR", "ITA", "JAM", "JPN", "JEY", "JOR", "KAZ", "KEN",
+    "KIR", "PRK", "KOR", "KWT", "KGZ", "LAO", "LVA", "LBN", "LSO", "LBR", "LBY", "LIE", "LTU",
+    "LUX", "MAC", "MDG", "MWI", "MYS", "MDV", "MLI", "MLT", "MHL", "MTQ", "MRT", "MUS", "MYT",
+    "MEX", "FSM", "MDA", "MCO", "MNG", "MNE", "MSR", "MAR", "MOZ", "MMR", "NAM", "NRU", "NPL",
+    "NLD", "NCL", "NZL", "NIC", "NER", "NGA", "NIU", "NFK", "MKD", "MNP", "NOR", "OMN", "PAK",
+    "PLW", "PSE", "PAN", "PNG", "PRY", "PER", "PHL", "PCN", "POL", "PRT", "PRI", "QAT", "REU",
+    "ROU", "RUS", "RWA", "BLM", "SHN", "KNA", "LCA", "MAF", "SPM", "VCT", "WSM", "SMR", "STP",
+    "SAU", "SEN", "SRB", "SYC", "SLE", "SGP", "SXM", "SVK", "SVN", "SLB", "SOM", "ZAF", "SGS",
+    "SSD", "ESP", "LKA", "SDN", "SUR", "SJM", "SWE", "CHE", "SYR", "TWN", "TJK", "TZA", "THA",
+    "TLS", "TGO", "TKL", "TON", "TTO", "TUN", "TUR", "TKM", "TCA", "TUV", "UGA", "UKR", "ARE",
+    "GBR", "USA", "UMI", "URY", "UZB", "VUT", "VEN", "VNM", "VGB", "VIR", "WLF", "ESH", "YEM",
+    "ZMB", "ZWE",
 ];
-
 
 ///ALL the 3 length numeric str codes of Countrys
-pub const ALL_NUMERIC_STR: & [&str] = &[
-
-
-"004",
-"248",
-"008",
-"012",
-"016",
-"020",
-"024",
-"660",
-"010",
-"028",
-"032",
-"051",
-"533",
-"036",
-"040",
-"031",
-"044",
-"048",
-"050",
-"052",
-"112",
-"056",
-"084",
-"204",
-"060",
-"064",
-"068",
-"535",
-"070",
-"072",
-"074",
-"076",
-"086",
-"096",
-"100",
-"854",
-"108",
-"132",
-"116",
-"120",
-"124",
-"136",
-"140",
-"148",
-"152",
-"156",
-"162",
-"166",
-"170",
-"174",
-"178",
-"180",
-"184",
-"188",
-"384",
-"191",
-"192",
-"531",
-"196",
-"203",
-"208",
-"262",
-"212",
-"214",
-"218",
-"818",
-"222",
-"226",
-"232",
-"233",
-"748",
-"231",
-"238",
-"234",
-"242",
-"246",
-"250",
-"254",
-"258",
-"260",
-"266",
-"270",
-"268",
-"276",
-"288",
-"292",
-"300",
-"304",
-"308",
-"312",
-"316",
-"320",
-"831",
-"324",
-"624",
-"328",
-"332",
-"334",
-"336",
-"340",
-"344",
-"348",
-"352",
-"356",
-"360",
-"364",
-"368",
-"372",
-"833",
-"376",
-"380",
-"388",
-"392",
-"832",
-"400",
-"398",
-"404",
-"296",
-"408",
-"410",
-"414",
-"417",
-"418",
-"428",
-"422",
-"426",
-"430",
-"434",
-"438",
-"440",
-"442",
-"446",
-"450",
-"454",
-"458",
-"462",
-"466",
-"470",
-"584",
-"474",
-"478",
-"480",
-"175",
-"484",
-"583",
-"498",
-"492",
-"496",
-"499",
-"500",
-"504",
-"508",
-"104",
-"516",
-"520",
-"524",
-"528",
-"540",
-"554",
-"558",
-"562",
-"566",
-"570",
-"574",
-"807",
-"580",
-"578",
-"512",
-"586",
-"585",
-"275",
-"591",
-"598",
-"600",
-"604",
-"608",
-"612",
-"616",
-"620",
-"630",
-"634",
-"638",
-"642",
-"643",
-"646",
-"652",
-"654",
-"659",
-"662",
-"663",
-"666",
-"670",
-"882",
-"674",
-"678",
-"682",
-"686",
-"688",
-"690",
-"694",
-"702",
-"534",
-"703",
-"705",
-"090",
-"706",
-"710",
-"239",
-"728",
-"724",
-"144",
-"729",
-"740",
-"744",
-"752",
-"756",
-"760",
-"158",
-"762",
-"834",
-"764",
-"626",
-"768",
-"772",
-"776",
-"780",
-"788",
-"792",
-"795",
-"796",
-"798",
-"800",
-"804",
-"784",
-"826",
-"840",
-"581",
-"858",
-"860",
-"548",
-"862",
-"704",
-"092",
-"850",
-"876",
-"732",
-"887",
-"894",
-"716",
-
-
+pub const ALL_NUMERIC_STR: &[&str] = &[
+    "004", "248", "008", "012", "016", "020", "024", "660", "010", "028", "032", "051", "533",
+    "036", "040", "031", "044", "048", "050", "052", "112", "056", "084", "204", "060", "064",
+    "068", "535", "070", "072", "074", "076", "086", "096", "100", "854", "108", "132", "116",
+    "120", "124", "136", "140", "148", "152", "156", "162", "166", "170", "174", "178", "180",
+    "184", "188", "384", "191", "192", "531", "196", "203", "208", "262", "212", "214", "218",
+    "818", "222", "226", "232", "233", "748", "231", "238", "234", "242", "246", "250", "254",
+    "258", "260", "266", "270", "268", "276", "288", "292", "300", "304", "308", "312", "316",
+    "320", "831", "324", "624", "328", "332", "334", "336", "340", "344", "348", "352", "356",
+    "360", "364", "368", "372", "833", "376", "380", "388", "392", "832", "400", "398", "404",
+    "296", "408", "410", "414", "417", "418", "428", "422", "426", "430", "434", "438", "440",
+    "442", "446", "450", "454", "458", "462", "466", "470", "584", "474", "478", "480", "175",
+    "484", "583", "498", "492", "496", "499", "500", "504", "508", "104", "516", "520", "524",
+    "528", "540", "554", "558", "562", "566", "570", "574", "807", "580", "578", "512", "586",
+    "585", "275", "591", "598", "600", "604", "608", "612", "616", "620", "630", "634", "638",
+    "642", "643", "646", "652", "654", "659", "662", "663", "666", "670", "882", "674", "678",
+    "682", "686", "688", "690", "694", "702", "534", "703", "705", "090", "706", "710", "239",
+    "728", "724", "144", "729", "740", "744", "752", "756", "760", "158", "762", "834", "764",
+    "626", "768", "772", "776", "780", "788", "792", "795", "796", "798", "800", "804", "784",
+    "826", "840", "581", "858", "860", "548", "862", "704", "092", "850", "876", "732", "887",
+    "894", "716",
 ];
-
 
 ///ALL the  numeric  codes of Countrys
-pub const ALL_NUMERIC: & [i32] = &[
-
-
-4,
-248,
-8,
-12,
-16,
-20,
-24,
-660,
-10,
-28,
-32,
-51,
-533,
-36,
-40,
-31,
-44,
-48,
-50,
-52,
-112,
-56,
-84,
-204,
-60,
-64,
-68,
-535,
-70,
-72,
-74,
-76,
-86,
-96,
-100,
-854,
-108,
-132,
-116,
-120,
-124,
-136,
-140,
-148,
-152,
-156,
-162,
-166,
-170,
-174,
-178,
-180,
-184,
-188,
-384,
-191,
-192,
-531,
-196,
-203,
-208,
-262,
-212,
-214,
-218,
-818,
-222,
-226,
-232,
-233,
-748,
-231,
-238,
-234,
-242,
-246,
-250,
-254,
-258,
-260,
-266,
-270,
-268,
-276,
-288,
-292,
-300,
-304,
-308,
-312,
-316,
-320,
-831,
-324,
-624,
-328,
-332,
-334,
-336,
-340,
-344,
-348,
-352,
-356,
-360,
-364,
-368,
-372,
-833,
-376,
-380,
-388,
-392,
-832,
-400,
-398,
-404,
-296,
-408,
-410,
-414,
-417,
-418,
-428,
-422,
-426,
-430,
-434,
-438,
-440,
-442,
-446,
-450,
-454,
-458,
-462,
-466,
-470,
-584,
-474,
-478,
-480,
-175,
-484,
-583,
-498,
-492,
-496,
-499,
-500,
-504,
-508,
-104,
-516,
-520,
-524,
-528,
-540,
-554,
-558,
-562,
-566,
-570,
-574,
-807,
-580,
-578,
-512,
-586,
-585,
-275,
-591,
-598,
-600,
-604,
-608,
-612,
-616,
-620,
-630,
-634,
-638,
-642,
-643,
-646,
-652,
-654,
-659,
-662,
-663,
-666,
-670,
-882,
-674,
-678,
-682,
-686,
-688,
-690,
-694,
-702,
-534,
-703,
-705,
-90,
-706,
-710,
-239,
-728,
-724,
-144,
-729,
-740,
-744,
-752,
-756,
-760,
-158,
-762,
-834,
-764,
-626,
-768,
-772,
-776,
-780,
-788,
-792,
-795,
-796,
-798,
-800,
-804,
-784,
-826,
-840,
-581,
-858,
-860,
-548,
-862,
-704,
-92,
-850,
-876,
-732,
-887,
-894,
-716,
-
-
+pub const ALL_NUMERIC: &[i32] = &[
+    4, 248, 8, 12, 16, 20, 24, 660, 10, 28, 32, 51, 533, 36, 40, 31, 44, 48, 50, 52, 112, 56, 84,
+    204, 60, 64, 68, 535, 70, 72, 74, 76, 86, 96, 100, 854, 108, 132, 116, 120, 124, 136, 140, 148,
+    152, 156, 162, 166, 170, 174, 178, 180, 184, 188, 384, 191, 192, 531, 196, 203, 208, 262, 212,
+    214, 218, 818, 222, 226, 232, 233, 748, 231, 238, 234, 242, 246, 250, 254, 258, 260, 266, 270,
+    268, 276, 288, 292, 300, 304, 308, 312, 316, 320, 831, 324, 624, 328, 332, 334, 336, 340, 344,
+    348, 352, 356, 360, 364, 368, 372, 833, 376, 380, 388, 392, 832, 400, 398, 404, 296, 408, 410,
+    414, 417, 418, 428, 422, 426, 430, 434, 438, 440, 442, 446, 450, 454, 458, 462, 466, 470, 584,
+    474, 478, 480, 175, 484, 583, 498, 492, 496, 499, 500, 504, 508, 104, 516, 520, 524, 528, 540,
+    554, 558, 562, 566, 570, 574, 807, 580, 578, 512, 586, 585, 275, 591, 598, 600, 604, 608, 612,
+    616, 620, 630, 634, 638, 642, 643, 646, 652, 654, 659, 662, 663, 666, 670, 882, 674, 678, 682,
+    686, 688, 690, 694, 702, 534, 703, 705, 90, 706, 710, 239, 728, 724, 144, 729, 740, 744, 752,
+    756, 760, 158, 762, 834, 764, 626, 768, 772, 776, 780, 788, 792, 795, 796, 798, 800, 804, 784,
+    826, 840, 581, 858, 860, 548, 862, 704, 92, 850, 876, 732, 887, 894, 716,
 ];
-
 
 ///ALL the Countrys struct
-pub const ALL: & [CountryCode] = &[
-
-
-AF,
-AX,
-AL,
-DZ,
-AS,
-AD,
-AO,
-AI,
-AQ,
-AG,
-AR,
-AM,
-AW,
-AU,
-AT,
-AZ,
-BS,
-BH,
-BD,
-BB,
-BY,
-BE,
-BZ,
-BJ,
-BM,
-BT,
-BO,
-BQ,
-BA,
-BW,
-BV,
-BR,
-IO,
-BN,
-BG,
-BF,
-BI,
-CV,
-KH,
-CM,
-CA,
-KY,
-CF,
-TD,
-CL,
-CN,
-CX,
-CC,
-CO,
-KM,
-CG,
-CD,
-CK,
-CR,
-CI,
-HR,
-CU,
-CW,
-CY,
-CZ,
-DK,
-DJ,
-DM,
-DO,
-EC,
-EG,
-SV,
-GQ,
-ER,
-EE,
-SZ,
-ET,
-FK,
-FO,
-FJ,
-FI,
-FR,
-GF,
-PF,
-TF,
-GA,
-GM,
-GE,
-DE,
-GH,
-GI,
-GR,
-GL,
-GD,
-GP,
-GU,
-GT,
-GG,
-GN,
-GW,
-GY,
-HT,
-HM,
-VA,
-HN,
-HK,
-HU,
-IS,
-IN,
-ID,
-IR,
-IQ,
-IE,
-IM,
-IL,
-IT,
-JM,
-JP,
-JE,
-JO,
-KZ,
-KE,
-KI,
-KP,
-KR,
-KW,
-KG,
-LA,
-LV,
-LB,
-LS,
-LR,
-LY,
-LI,
-LT,
-LU,
-MO,
-MG,
-MW,
-MY,
-MV,
-ML,
-MT,
-MH,
-MQ,
-MR,
-MU,
-YT,
-MX,
-FM,
-MD,
-MC,
-MN,
-ME,
-MS,
-MA,
-MZ,
-MM,
-NA,
-NR,
-NP,
-NL,
-NC,
-NZ,
-NI,
-NE,
-NG,
-NU,
-NF,
-MK,
-MP,
-NO,
-OM,
-PK,
-PW,
-PS,
-PA,
-PG,
-PY,
-PE,
-PH,
-PN,
-PL,
-PT,
-PR,
-QA,
-RE,
-RO,
-RU,
-RW,
-BL,
-SH,
-KN,
-LC,
-MF,
-PM,
-VC,
-WS,
-SM,
-ST,
-SA,
-SN,
-RS,
-SC,
-SL,
-SG,
-SX,
-SK,
-SI,
-SB,
-SO,
-ZA,
-GS,
-SS,
-ES,
-LK,
-SD,
-SR,
-SJ,
-SE,
-CH,
-SY,
-TW,
-TJ,
-TZ,
-TH,
-TL,
-TG,
-TK,
-TO,
-TT,
-TN,
-TR,
-TM,
-TC,
-TV,
-UG,
-UA,
-AE,
-GB,
-US,
-UM,
-UY,
-UZ,
-VU,
-VE,
-VN,
-VG,
-VI,
-WF,
-EH,
-YE,
-ZM,
-ZW,
-
-
+pub const ALL: &[CountryCode] = &[
+    AF, AX, AL, DZ, AS, AD, AO, AI, AQ, AG, AR, AM, AW, AU, AT, AZ, BS, BH, BD, BB, BY, BE, BZ, BJ,
+    BM, BT, BO, BQ, BA, BW, BV, BR, IO, BN, BG, BF, BI, CV, KH, CM, CA, KY, CF, TD, CL, CN, CX, CC,
+    CO, KM, CG, CD, CK, CR, CI, HR, CU, CW, CY, CZ, DK, DJ, DM, DO, EC, EG, SV, GQ, ER, EE, SZ, ET,
+    FK, FO, FJ, FI, FR, GF, PF, TF, GA, GM, GE, DE, GH, GI, GR, GL, GD, GP, GU, GT, GG, GN, GW, GY,
+    HT, HM, VA, HN, HK, HU, IS, IN, ID, IR, IQ, IE, IM, IL, IT, JM, JP, JE, JO, KZ, KE, KI, KP, KR,
+    KW, KG, LA, LV, LB, LS, LR, LY, LI, LT, LU, MO, MG, MW, MY, MV, ML, MT, MH, MQ, MR, MU, YT, MX,
+    FM, MD, MC, MN, ME, MS, MA, MZ, MM, NA, NR, NP, NL, NC, NZ, NI, NE, NG, NU, NF, MK, MP, NO, OM,
+    PK, PW, PS, PA, PG, PY, PE, PH, PN, PL, PT, PR, QA, RE, RO, RU, RW, BL, SH, KN, LC, MF, PM, VC,
+    WS, SM, ST, SA, SN, RS, SC, SL, SG, SX, SK, SI, SB, SO, ZA, GS, SS, ES, LK, SD, SR, SJ, SE, CH,
+    SY, TW, TJ, TZ, TH, TL, TG, TK, TO, TT, TN, TR, TM, TC, TV, UG, UA, AE, GB, US, UM, UY, UZ, VU,
+    VE, VN, VG, VI, WF, EH, YE, ZM, ZW,
 ];
-

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -1,0 +1,151 @@
+#[cfg(feature = "serde")]
+mod tests {
+    extern crate serde_json;
+
+    use rust_iso3166::iso3166_2::from_code as from_code_2;
+    use rust_iso3166::iso3166_3::from_code as from_code_3;
+    use rust_iso3166::{from_alpha2, from_alpha3};
+
+    #[test]
+    fn test_country_code_serde() {
+        let au = from_alpha2("AU").unwrap();
+        let au_json = serde_json::to_string(&au).unwrap();
+        assert_eq!(au_json, "\"AU\"");
+
+        let us = from_alpha3("USA").unwrap();
+        let us_json = serde_json::to_string(&us).unwrap();
+        assert_eq!(us_json, "\"US\"");
+
+        let au_deserialized: rust_iso3166::CountryCode = serde_json::from_str("\"AU\"").unwrap();
+        assert_eq!(au_deserialized.alpha2, "AU");
+        assert_eq!(au_deserialized.alpha3, "AUS");
+
+        let us_deserialized: rust_iso3166::CountryCode = serde_json::from_str("\"USA\"").unwrap();
+        assert_eq!(us_deserialized.alpha2, "US");
+        assert_eq!(us_deserialized.alpha3, "USA");
+    }
+
+    #[test]
+    fn test_subdivision_serde() {
+        let gb_edh = from_code_2("GB-EDH").unwrap();
+        let gb_edh_json = serde_json::to_string(&gb_edh).unwrap();
+        assert_eq!(gb_edh_json, "\"GB-EDH\"");
+
+        let gb_edh_deserialized: rust_iso3166::iso3166_2::Subdivision =
+            serde_json::from_str("\"GB-EDH\"").unwrap();
+        assert_eq!(gb_edh_deserialized.code, "GB-EDH");
+        assert_eq!(gb_edh_deserialized.name, "Edinburgh, City of");
+    }
+
+    #[test]
+    fn test_country_code3_serde() {
+        let pzpa = from_code_3("PZPA").unwrap();
+        let pzpa_json = serde_json::to_string(&pzpa).unwrap();
+        assert_eq!(pzpa_json, "\"PZPA\"");
+
+        let pzpa_deserialized: rust_iso3166::iso3166_3::CountryCode3 =
+            serde_json::from_str("\"PZPA\"").unwrap();
+        assert_eq!(pzpa_deserialized.code, "PZPA");
+        assert_eq!(pzpa_deserialized.name, "Panama Canal Zone");
+    }
+
+    #[test]
+    fn test_country_code_case_insensitive() {
+        let au_lower: rust_iso3166::CountryCode = serde_json::from_str("\"au\"").unwrap();
+        assert_eq!(au_lower.alpha2, "AU");
+        assert_eq!(au_lower.alpha3, "AUS");
+
+        let us_mixed: rust_iso3166::CountryCode = serde_json::from_str("\"uSa\"").unwrap();
+        assert_eq!(us_mixed.alpha2, "US");
+        assert_eq!(us_mixed.alpha3, "USA");
+
+        let gb_upper: rust_iso3166::CountryCode = serde_json::from_str("\"GB\"").unwrap();
+        assert_eq!(gb_upper.alpha2, "GB");
+        assert_eq!(gb_upper.alpha3, "GBR");
+    }
+
+    #[test]
+    fn test_subdivision_case_insensitive() {
+        let gb_edh_lower: rust_iso3166::iso3166_2::Subdivision =
+            serde_json::from_str("\"gb-edh\"").unwrap();
+        assert_eq!(gb_edh_lower.code, "GB-EDH");
+        assert_eq!(gb_edh_lower.name, "Edinburgh, City of");
+
+        let gb_edh_mixed: rust_iso3166::iso3166_2::Subdivision =
+            serde_json::from_str("\"Gb-Edh\"").unwrap();
+        assert_eq!(gb_edh_mixed.code, "GB-EDH");
+        assert_eq!(gb_edh_mixed.name, "Edinburgh, City of");
+    }
+
+    #[test]
+    fn test_country_code3_case_insensitive() {
+        let pzpa_lower: rust_iso3166::iso3166_3::CountryCode3 =
+            serde_json::from_str("\"pzpa\"").unwrap();
+        assert_eq!(pzpa_lower.code, "PZPA");
+        assert_eq!(pzpa_lower.name, "Panama Canal Zone");
+
+        let pzpa_mixed: rust_iso3166::iso3166_3::CountryCode3 =
+            serde_json::from_str("\"PzPa\"").unwrap();
+        assert_eq!(pzpa_mixed.code, "PZPA");
+        assert_eq!(pzpa_mixed.name, "Panama Canal Zone");
+    }
+
+    #[test]
+    fn test_invalid_country_code() {
+        let result: Result<rust_iso3166::CountryCode, _> = serde_json::from_str("\"XX\"");
+        assert!(result.is_err());
+
+        let result: Result<rust_iso3166::CountryCode, _> = serde_json::from_str("\"XXX\"");
+        assert!(result.is_err());
+
+        let result: Result<rust_iso3166::CountryCode, _> = serde_json::from_str("\"\"");
+        assert!(result.is_err());
+
+        let result: Result<rust_iso3166::CountryCode, _> = serde_json::from_str("\"1234\"");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_subdivision() {
+        let result: Result<rust_iso3166::iso3166_2::Subdivision, _> =
+            serde_json::from_str("\"XX-XX\"");
+        assert!(result.is_err());
+
+        let result: Result<rust_iso3166::iso3166_2::Subdivision, _> =
+            serde_json::from_str("\"GB-XXX\"");
+        assert!(result.is_err());
+
+        let result: Result<rust_iso3166::iso3166_2::Subdivision, _> = serde_json::from_str("\"\"");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_country_code3() {
+        let result: Result<rust_iso3166::iso3166_3::CountryCode3, _> =
+            serde_json::from_str("\"XXXX\"");
+        assert!(result.is_err());
+
+        let result: Result<rust_iso3166::iso3166_3::CountryCode3, _> =
+            serde_json::from_str("\"XXX\"");
+        assert!(result.is_err());
+
+        let result: Result<rust_iso3166::iso3166_3::CountryCode3, _> = serde_json::from_str("\"\"");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_boundary_cases() {
+        let result: Result<rust_iso3166::CountryCode, _> = serde_json::from_str("\"036\"");
+        assert!(result.is_err()); // Direct deserialization of numeric codes is not currently supported
+
+        let result: Result<rust_iso3166::CountryCode, _> = serde_json::from_str("\"A@\"");
+        assert!(result.is_err());
+
+        let result: Result<rust_iso3166::CountryCode, _> = serde_json::from_str("\"🫡❤️\"");
+        assert!(result.is_err());
+
+        let result: Result<rust_iso3166::CountryCode, _> =
+            serde_json::from_str("\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"");
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
- Implement Serialize/Deserialize for ISO3166-2 and ISO3166-3
- Improve code by cargo fmt
- Fix clippy warning
- Add serde round-trip tests to ensure correctness

**Checklist:**
- [x] Run `cargo fmt`
- [X] `cargo clippy` no warning
- [X] All tests passed
- [X] No breaking change

**Note:**
Run `cargo add rust_iso3166 -F serde` to enable the feature

Direct deserialization of numeric codes is not currently supported

Close #13 
