### PR TITLE
Cli optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 phf = { version = "^0.13.1", features = ["macros"] }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 prettytable-rs = { version = "^0.10", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,19 +2,19 @@
 name = "rust_iso3166"
 version = "0.1.14"
 edition = "2021"
-description="ISO 3166-1 (Codes for the representation of names of countries and their subdivisions – Part 1: Country codes) is a standard defining codes for the names of countries, dependent territories, and special areas of geographical interest. It is the first part of the ISO 3166 standard published by the International Organization for Standardization."
-repository="https://github.com/rust-iso/rust_iso3166"
-license="Apache-2.0"
+description = "ISO 3166-1 (Codes for the representation of names of countries and their subdivisions – Part 1: Country codes) is a standard defining codes for the names of countries, dependent territories, and special areas of geographical interest. It is the first part of the ISO 3166 standard published by the International Organization for Standardization."
+repository = "https://github.com/rust-iso/rust_iso3166"
+license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 exclude = ["src/*.py"]
 documentation = "https://docs.rs/rust_iso3166/"
-keywords=["ISO3166", "ISO3166-1", "ISO3166-2", "ISO3166-3"]
+keywords = ["ISO3166", "ISO3166-1", "ISO3166-2", "ISO3166-3"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-phf = { version = "^0.11.1", features = ["macros"] }
+phf = { version = "^0.13.1", features = ["macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 prettytable-rs = "^0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,14 @@ exclude = ["src/*.py"]
 documentation = "https://docs.rs/rust_iso3166/"
 keywords = ["ISO3166", "ISO3166-1", "ISO3166-2", "ISO3166-3"]
 
+[features]
+cli = ["dep:prettytable-rs"]
+
+[[bin]]
+name = "main"
+path = "src/bin/main.rs"
+required-features = ["cli"]
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 
@@ -17,7 +25,7 @@ crate-type = ["cdylib", "rlib"]
 phf = { version = "^0.13.1", features = ["macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-prettytable-rs = "^0.10"
+prettytable-rs = { version = "^0.10", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "^0.2.83"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,55 +1,43 @@
-#[cfg(not(target_arch = "wasm32"))]
 fn main() {
-  use prettytable::{row, Table};
-  use std::env;
+    use prettytable::{row, Table};
+    use std::env;
 
-  let mut args = env::args();
-  let script_name = match args.next() {
-    Some(arg) => arg,
-    None => String::from(""),
-  };
-  let query = match args.next() {
-    Some(arg) => arg,
-    None => String::from(""),
-  };
-  let query = &query.to_lowercase();
+    let mut args = env::args();
+    let script_name = args.next().unwrap_or_default();
+    let query = args.next().unwrap_or_default();
+    let query = &query.to_lowercase();
 
-  eprintln!("Usage: {} [query]", script_name);
-  let mut found = false;
-  let mut table = Table::new();
-  table.add_row(row!["Name", "Alpha2", "Alpha3", "Numeric"]);
+    eprintln!("Usage: {} [query]", script_name);
+    let mut found = false;
+    let mut table = Table::new();
+    table.add_row(row!["Name", "Alpha2", "Alpha3", "Numeric"]);
 
-  for country in rust_iso3166::ALL {
-    if country.alpha2.to_lowercase().contains(query)
-      || country.alpha3.to_lowercase().contains(query)
-      || country.numeric_str().to_lowercase().contains(query)
-    {
-      table.add_row(row![
-        country.name,
-        country.alpha2,
-        country.alpha3,
-        country.numeric_str()
-      ]);
-      found = true;
-    }
-  }
-
-  if !found {
     for country in rust_iso3166::ALL {
-      if country.name.to_lowercase().contains(query) {
-        table.add_row(row![
-          country.name,
-          country.alpha2,
-          country.alpha3,
-          country.numeric_str()
-        ]);
-      }
+        if country.alpha2.to_lowercase().contains(query)
+            || country.alpha3.to_lowercase().contains(query)
+            || country.numeric_str().to_lowercase().contains(query)
+        {
+            table.add_row(row![
+                country.name,
+                country.alpha2,
+                country.alpha3,
+                country.numeric_str()
+            ]);
+            found = true;
+        }
     }
-  }
-  table.printstd();
-}
 
-#[cfg(target_arch = "wasm32")]
-fn main() {
-  unimplemented!();
+    if !found {
+        for country in rust_iso3166::ALL {
+            if country.name.to_lowercase().contains(query) {
+                table.add_row(row![
+                    country.name,
+                    country.alpha2,
+                    country.alpha3,
+                    country.numeric_str()
+                ]);
+            }
+        }
+    }
+    table.printstd();
 }


### PR DESCRIPTION
This is one way of solving #14. Since the binary is just called `main`, I suspect it's not really installed by people as a standalone CLI, and used more for testing purposes, so I just put it behind a "cli" cargo feature.